### PR TITLE
Add a convert_to_gpkg function to the layer source object

### DIFF
--- a/layer.py
+++ b/layer.py
@@ -432,10 +432,7 @@ class LayerSource(object):
         :param keep_existent: if True and target file already exists, keep it as it is
         """
 
-        if (
-            not self.layer.type() == QgsMapLayer.VectorLayer
-            or not self.layer.isValid()
-        ):
+        if not self.layer.type() == QgsMapLayer.VectorLayer or not self.layer.isValid():
             return
 
         parts = None

--- a/layer.py
+++ b/layer.py
@@ -434,7 +434,7 @@ class LayerSource(object):
 
         if (
             not self.layer.type() == QgsMapLayer.VectorLayer
-            or not self.layer.dataProvider()
+            or not self.layer.isValid()
         ):
             return
 

--- a/offline_converter.py
+++ b/offline_converter.py
@@ -106,7 +106,9 @@ class OfflineConverter(QObject):
         project_filename = project.baseName()
         xml_elements_to_preserve = {}
 
-        on_original_project_read = self._on_original_project_read_wrapper(xml_elements_to_preserve)
+        on_original_project_read = self._on_original_project_read_wrapper(
+            xml_elements_to_preserve
+        )
         project.readProject.connect(on_original_project_read)
         project.read(project.fileName())
         project.readProject.disconnect(on_original_project_read)
@@ -487,7 +489,9 @@ class OfflineConverter(QObject):
                                 )
 
             # Now we have a project state which can be saved as offline project
-            on_original_project_write = self._on_original_project_write_wrapper(xml_elements_to_preserve)
+            on_original_project_write = self._on_original_project_write_wrapper(
+                xml_elements_to_preserve
+            )
             project.writeProject.connect(on_original_project_write)
             QgsProject.instance().write(project_path)
             project.writeProject.disconnect(on_original_project_write)
@@ -577,14 +581,20 @@ class OfflineConverter(QObject):
 
     def _on_original_project_read_wrapper(self, elements):
         def on_original_project_read(doc):
-            if not elements.get('map_canvas'):
-                elements['map_canvas'] = elements.get('map_canvas', get_themapcanvas(doc))
+            if not elements.get("map_canvas"):
+                elements["map_canvas"] = elements.get(
+                    "map_canvas", get_themapcanvas(doc)
+                )
+
         return on_original_project_read
 
     def _on_original_project_write_wrapper(self, elements):
         def on_original_project_write(doc):
-            if not get_themapcanvas(doc) and elements.get('map_canvas'):
-                doc.elementsByTagName('qgis').at(0).appendChild(elements.get('map_canvas'))
+            if not get_themapcanvas(doc) and elements.get("map_canvas"):
+                doc.elementsByTagName("qgis").at(0).appendChild(
+                    elements.get("map_canvas")
+                )
+
         return on_original_project_write
 
     def offline_editing_task_progress(self, progress):

--- a/offline_converter.py
+++ b/offline_converter.py
@@ -541,7 +541,6 @@ class OfflineConverter(QObject):
     def on_offline_editing_max_changed(self, _, mode_count):
         self.__max_task_progress = mode_count
 
-    @pyqtSlot(int)
     def offline_editing_task_progress(self, progress):
         self.task_progress_updated.emit(progress, self.__max_task_progress)
 

--- a/offline_converter.py
+++ b/offline_converter.py
@@ -538,7 +538,6 @@ class OfflineConverter(QObject):
         )
         self.total_progress_updated.emit(layer_index, layer_count, msg)
 
-    @pyqtSlot("QgsOfflineEditing::ProgressMode", int)
     def on_offline_editing_max_changed(self, _, mode_count):
         self.__max_task_progress = mode_count
 

--- a/utils/xml.py
+++ b/utils/xml.py
@@ -18,7 +18,9 @@
 """
 
 from typing import Optional
+
 from PyQt5.QtXml import QDomDocument, QDomElement
+
 
 def get_themapcanvas(doc: QDomDocument) -> Optional[QDomElement]:
     """Find the "themapcanvas" DOM element in the QGIS project file.
@@ -36,10 +38,7 @@ def get_themapcanvas(doc: QDomDocument) -> Optional[QDomElement]:
     for i in range(nodes.size()):
         node = nodes.item(i)
         el = node.toElement()
-        if (
-            el.hasAttribute("name")
-            and el.attribute("name") == "theMapCanvas"
-        ):
+        if el.hasAttribute("name") and el.attribute("name") == "theMapCanvas":
             return el
 
     return None

--- a/utils/xml.py
+++ b/utils/xml.py
@@ -1,0 +1,45 @@
+"""
+/***************************************************************************
+ QFieldSync
+                              -------------------
+        begin                : 2016
+        copyright            : (C) 2016 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from typing import Optional
+from PyQt5.QtXml import QDomDocument, QDomElement
+
+def get_themapcanvas(doc: QDomDocument) -> Optional[QDomElement]:
+    """Find the "themapcanvas" DOM element in the QGIS project file.
+
+    NOTE if no QgsGui available, QgsProject::write() will discard the "themapcanvas" element.
+
+    Args:
+        doc (QDomDocument): project DOM document
+
+    Returns:
+        Optional[QDomElement]: the "themapcanvas" element
+    """
+    nodes = doc.elementsByTagName("mapcanvas")
+
+    for i in range(nodes.size()):
+        node = nodes.item(i)
+        el = node.toElement()
+        if (
+            el.hasAttribute("name")
+            and el.attribute("name") == "theMapCanvas"
+        ):
+            return el
+
+    return None


### PR DESCRIPTION
This new function is used in the new qfieldsync "convert to cloud project" feature (more bits coming in on the qfieldsync repository).

The function takes a source layer and writes a geopackage equivalent in the provided destination directory. If the source layer is a geopackage, the function merely copies the dataset.

If the source layer isn't a geopackage, it'll make a copy of the original dataset while being careful to respect pre-existing subset string filter, and insuring that joined fields as well as virtual fields remain as such (i.e. aren't made permanent).