### PR TITLE
Fix cloud project converter against QGIS 3.16 windows (old installer)

### DIFF
--- a/layer.py
+++ b/layer.py
@@ -519,12 +519,15 @@ class LayerSource(object):
             options = QgsVectorFileWriter.SaveVectorOptions()
             options.fileEncoding = "UTF-8"
             options.driverName = "GPKG"
-            (error, dest_file) = QgsVectorFileWriter.writeAsVectorFormatV2(
+            (error, returned_dest_file) = QgsVectorFileWriter.writeAsVectorFormatV2(
                 source_layer, dest_file, QgsCoordinateTransformContext(), options
             )
             if error != QgsVectorFileWriter.NoError:
                 return
-            new_source = dest_file
+            if returned_dest_file:
+                new_source = returned_dest_file
+            else:
+                new_source = dest_file
 
         self._change_data_source(new_source, "ogr")
         if layer_subset_string:


### PR DESCRIPTION
This fixes a serious bug with the qfieldsync plugin when run against QGIS 3.16 windows (using the old installer). It was discovered during the QField workshop @ FOSS4G by participant  Aaron Laver.

Long story short here, there's a problem with the old installer (and/or 3.16 itself) whereas the python API for the QgsVectorFileWriter.writeAsVectorFormatV2 function doesn't return the tuple as stated in the API documentation. The fix here is harmless. It's good practice to use the returned value, but if it ain't there, we can use the destination filepath we pass on as parameter.

With this fix in, I can successfully convert project to QFieldCloud using 3.16 LTR on windows :partying_face: 