### PR TITLE
Remove support for offline_copy_only_selected_features configuration

### DIFF
--- a/offline_converter.py
+++ b/offline_converter.py
@@ -239,27 +239,13 @@ class OfflineConverter(QObject):
                 non_utf8_encoding_layers[layer.name()] = layer.dataProvider().encoding()
 
             if layer_action == SyncAction.OFFLINE:
-                if (
-                    self.project_configuration.offline_copy_only_aoi
-                    and not self.project_configuration.offline_copy_only_selected_features
-                ):
+                if self.project_configuration.offline_copy_only_aoi:
                     extent = QgsCoordinateTransform(
                         QgsCoordinateReferenceSystem(self.area_of_interest_crs),
                         layer.crs(),
                         QgsProject.instance(),
                     ).transformBoundingBox(self.area_of_interest.boundingBox())
                     layer.selectByRect(extent)
-                elif (
-                    self.project_configuration.offline_copy_only_aoi
-                    and self.project_configuration.offline_copy_only_selected_features
-                ):
-                    # This option is only possible via API
-                    QgsApplication.instance().messageLog().logMessage(
-                        self.tr(
-                            'Both "Area of Interest" and "only selected features" options were enabled, tha latter takes precedence.'
-                        ),
-                        "QFieldSync",
-                    )
 
                 if not layer.selectedFeatureCount():
                     layer.selectByIds([FID_NULL])
@@ -319,16 +305,12 @@ class OfflineConverter(QObject):
             gpkg_filename = "data.gpkg"
             if self.__offline_layers:
                 offline_layer_ids = [o_l.id() for o_l in self.__offline_layers]
-                only_selected = (
-                    self.project_configuration.offline_copy_only_aoi
-                    or self.project_configuration.offline_copy_only_selected_features
-                )
 
                 if not self.offline_editing.convertToOfflineProject(
                     str(self.export_folder),
                     gpkg_filename,
                     offline_layer_ids,
-                    only_selected,
+                    self.project_configuration.offline_copy_only_aoi,
                     self.offline_editing.GPKG,
                     None,
                 ):
@@ -340,16 +322,12 @@ class OfflineConverter(QObject):
             spatialite_filename = "data.sqlite"
             if self.__offline_layers:
                 offline_layer_ids = [o_l.id() for o_l in self.__offline_layers]
-                only_selected = (
-                    self.project_configuration.offline_copy_only_aoi
-                    or self.project_configuration.offline_copy_only_selected_features
-                )
 
                 if not self.offline_editing.convertToOfflineProject(
                     str(self.export_folder),
                     spatialite_filename,
                     offline_layer_ids,
-                    only_selected,
+                    self.project_configuration.offline_copy_only_aoi,
                     self.offline_editing.SpatiaLite,
                     None,
                 ):

--- a/project.py
+++ b/project.py
@@ -9,7 +9,6 @@ class ProjectProperties(object):
     BASE_MAP_TILE_SIZE = "/baseMapTileSize"
     BASE_MAP_MUPP = "/baseMapMupp"
     OFFLINE_COPY_ONLY_AOI = "/offlineCopyOnlyAoi"
-    OFFLINE_COPY_ONLY_SELECTED_FEATURES = "/offlineCopyOnlySelectedFeatures"
     ORIGINAL_PROJECT_PATH = "/originalProjectPath"
     IMPORTED_FILES_CHECKSUMS = "/importedFilesChecksums"
     LAYER_ACTION_PREFERENCE = "/layerActionPreference"
@@ -140,19 +139,6 @@ class ProjectConfiguration(object):
     def offline_copy_only_aoi(self, value):
         self.project.writeEntry(
             "qfieldsync", ProjectProperties.OFFLINE_COPY_ONLY_AOI, value
-        )
-
-    @property
-    def offline_copy_only_selected_features(self):
-        offline_copy_only_selected_features, _ = self.project.readBoolEntry(
-            "qfieldsync", ProjectProperties.OFFLINE_COPY_ONLY_SELECTED_FEATURES
-        )
-        return offline_copy_only_selected_features
-
-    @offline_copy_only_selected_features.setter
-    def offline_copy_only_selected_features(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.OFFLINE_COPY_ONLY_SELECTED_FEATURES, value
         )
 
     @property


### PR DESCRIPTION
The code remained there for quite some time, but it seems it is no longer needed, there is no UI and is threat for potential errors. As far as I know, @gacarrillor used the code in the past but this is no longer the case. Are you ok to remove it?