### PR TITLE
The metadata reader is available if the layer is not valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This library facilitates packaging and synchronizing QGIS projects for use with 
 
 This library is the heart of QFieldSync QGIS plugin.
 
-More information can be found in the [QField documentation](http://www.qfield.org/docs/qfieldsync/index.html).
+More information can be found in the [QField documentation](https://docs.qfield.org/get-started/).
 
 The plugin can be download on the [QGIS plugin repository](https://plugins.qgis.org/plugins/qfieldsync/).
 

--- a/layer.py
+++ b/layer.py
@@ -342,7 +342,7 @@ class LayerSource(object):
 
     @property
     def metadata(self) -> Optional[QgsProviderMetadata]:
-        if not self.layer.isValid() or not self.layer.dataProvider():
+        if not self.layer.dataProvider():
             return None
 
         return QgsProviderRegistry.instance().providerMetadata(


### PR DESCRIPTION
Rename metadata -> provider_metadata and decoded_metadata -> metadata

The renaming makes more sense and it's easier to understand.

Return the provider_metadata when the layer is invalid, but there is dataprovider.