### PR TITLE
Fix post-processing layers by ensuring the availability of remoteLayerId

### DIFF
--- a/offline_converter.py
+++ b/offline_converter.py
@@ -375,29 +375,6 @@ class OfflineConverter(QObject):
         # check if value relations point to offline layers and adjust if necessary
         for e_layer in project.mapLayers().values():
             if e_layer.type() == QgsMapLayer.VectorLayer:
-                # Before QGIS 3.14 the custom properties of a layer are not
-                # kept into the new layer during the conversion to offline project
-                # So we try to identify the new created layer by its name and
-                # we set the custom properties again.
-                if not e_layer.customProperty("QFieldSync/sourceDataPrimaryKeys"):
-                    o_layer_name = e_layer.name().rsplit(" ", 1)[0]
-                    o_layer_data = self.__layer_data_by_name.get(o_layer_name, None)
-
-                    if not o_layer_data:
-                        self.warning.emit(
-                            self.tr("QFieldSync"),
-                            self.tr(
-                                'Failed to find layer with name "{}". QFieldSync will not package that layer.'
-                            ).format(o_layer_name),
-                        )
-                        continue
-
-                    e_layer.setCustomProperty("remoteLayerId", o_layer_data["id"])
-                    e_layer.setCustomProperty(
-                        "QFieldSync/sourceDataPrimaryKeys",
-                        o_layer_data["pk_names"],
-                    )
-
                 remote_layer_id = e_layer.customProperty("QFieldSync/remoteLayerId")
                 if (
                     not remote_layer_id

--- a/offline_converter.py
+++ b/offline_converter.py
@@ -205,6 +205,8 @@ class OfflineConverter(QObject):
             self.__layer_data_by_id[layer.id()] = layer_data
             self.__layer_data_by_name[layer.name()] = layer_data
 
+            layer.setCustomProperty("QFieldSync/remoteLayerId", layer.id())
+
         if self.create_basemap and self.project_configuration.create_base_map:
             self._export_basemap()
 
@@ -396,10 +398,10 @@ class OfflineConverter(QObject):
                         o_layer_data["pk_names"],
                     )
 
+                remote_layer_id = e_layer.customProperty("QFieldSync/remoteLayerId")
                 if (
-                    not e_layer.customProperty("remoteLayerId")
-                    or e_layer.customProperty("remoteLayerId")
-                    not in self.__layer_data_by_id
+                    not remote_layer_id
+                    or remote_layer_id not in self.__layer_data_by_id
                 ):
                     self.warning.emit(
                         self.tr("QFieldSync"),
@@ -412,9 +414,10 @@ class OfflineConverter(QObject):
                 self.post_process_fields(e_layer)
 
     def post_process_fields(self, e_layer: QgsVectorLayer) -> None:
+        remote_layer_id = e_layer.customProperty("QFieldSync/remoteLayerId")
         e_layer_source = LayerSource(e_layer)
-        o_layer_data = self.__layer_data_by_id[e_layer.customProperty("remoteLayerId")]
-        o_layer_fields: QgsFields = o_layer_data["fields"]
+        o_layer_data = self.__layer_data_by_id[remote_layer_id]
+        o_layer_fields: QgsFields = o_layer_data["fields"]  # type: ignore
         o_layer_field_names = o_layer_fields.names()
 
         for e_field_name in e_layer_source.visible_fields_names():

--- a/offline_converter.py
+++ b/offline_converter.py
@@ -189,9 +189,10 @@ class OfflineConverter(QObject):
                     if "," in pk_name:
                         raise ValueError("Comma in field names not allowed")
                     pk_names.append(pk_name)
-                    layer.setCustomProperty(
-                        "QFieldSync/sourceDataPrimaryKeys", ",".join(pk_names)
-                    )
+
+                layer.setCustomProperty(
+                    "QFieldSync/sourceDataPrimaryKeys", ",".join(pk_names)
+                )
 
             layer_data: LayerData = {
                 "id": layer.id(),


### PR DESCRIPTION
- Fix https://github.com/opengisch/qfieldsync/issues/417 and https://github.com/opengisch/qfieldsync/issues/411 .
- Fix a QFieldSync respecting PostGIS layers configured as "direct access" not being packaged, as reported from @3nids
- Clean up code responsible for unsupported QGIS versions <3.16 