### PR TITLE
Add affected filename to warning

### DIFF
--- a/project_checker.py
+++ b/project_checker.py
@@ -316,10 +316,10 @@ class ProjectChecker:
         if layer_source.is_file and not isascii(layer_source.filename):
             return FeedbackResult(
                 self.tr(
-                    "Non ASCII character detected in the layer filename."
+                    "Non ASCII character detected in the layer filename {}."
                     "Working with file paths that are not in ASCII might cause problems."
                     "It is highly recommended to rename them to ASCII encoded paths."
-                ),
+                ).format(layer_source.filename),
             )
 
     def check_layer_primary_key(


### PR DESCRIPTION
This warning is triggered by filenames containing special characters. E.g. `Übersichtskarte.gpkg`. The filename containing the special character is not presented to the user so far (only the layername, that is not a problem by itself). By showing that also, the error is easier to interpret.