### PR TITLE
Make QFieldSync work with older QGIS versions prior to 3.30

### DIFF
--- a/libqfieldsync/offline_converter.py
+++ b/libqfieldsync/offline_converter.py
@@ -254,10 +254,20 @@ class OfflineConverter(QObject):
 
             if layer_action == SyncAction.OFFLINE:
                 if self.project_configuration.offline_copy_only_aoi:
-                    if (
-                        layer.geometryType() is not Qgis.GeometryType.Null
-                        and layer.geometryType() is not Qgis.GeometryType.Unknown
-                    ):
+                    if Qgis.QGIS_VERSION_INT >= 33000:
+                        no_geometry_types = [
+                            Qgis.GeometryType.Null,
+                            Qgis.GeometryType.Unknown,
+                        ]
+                    else:
+                        from qgis.core import QgsWkbTypes
+
+                        no_geometry_types = [
+                            QgsWkbTypes.GeometryType.Null,
+                            QgsWkbTypes.GeometryType.Unknown,
+                        ]
+
+                    if layer.geometryType() not in no_geometry_types:
                         try:
                             extent = QgsCoordinateTransform(
                                 QgsCoordinateReferenceSystem(self.area_of_interest_crs),


### PR DESCRIPTION
`Qgis.GeometryType` was introduced only in 3.30. See: https://api.qgis.org/api/3.30/classQgis.html#a84964253bb44012b246c20790799c04d 

![image](https://github.com/opengisch/libqfieldsync/assets/2820439/e1660c47-e04b-4f75-bcc4-bdcc5d6e6213)

Fix https://github.com/opengisch/qfieldsync/issues/552