### PR TITLE
Actually fix `QgsWkbTypes.GeometryType` in QGIS 3.28...

### DIFF
--- a/libqfieldsync/offline_converter.py
+++ b/libqfieldsync/offline_converter.py
@@ -263,8 +263,8 @@ class OfflineConverter(QObject):
                         from qgis.core import QgsWkbTypes
 
                         no_geometry_types = [
-                            QgsWkbTypes.GeometryType.Null,
-                            QgsWkbTypes.GeometryType.Unknown,
+                            QgsWkbTypes.GeometryType.NullGeometry,
+                            QgsWkbTypes.GeometryType.UnknownGeometry,
                         ]
 
                     if layer.geometryType() not in no_geometry_types:


### PR DESCRIPTION
Turns out `QgsWkbTypes.GeometryType.Null` are new additions, we have to use `QgsWkbTypes.GeometryType.NullGeometry`.

Tested in QGIS 3.28 docker image.

Follow-up of #60.