### PR TITLE
Add a context manager setting a custom `QgsProjectBadLayerHandler`

### DIFF
--- a/libqfieldsync/utils/bad_layer_handler.py
+++ b/libqfieldsync/utils/bad_layer_handler.py
@@ -21,7 +21,7 @@
 
 from typing import List
 
-from qgis.core import QgsProjectBadLayerHandler
+from qgis.core import QgsProject, QgsProjectBadLayerHandler
 from qgis.PyQt.QtXml import QDomNode
 
 
@@ -42,3 +42,35 @@ class BadLayerHandler(QgsProjectBadLayerHandler):
 
 # poor man singleton. Metaclass does not work because `QgsProjectBadLayerHandler` does not have the same metaclass. Other singleton options are not "good" enough.
 bad_layer_handler = BadLayerHandler()
+
+
+class set_bad_layer_handler:
+    """QGIS bad layer handler catches all unavailable layers, including the localized ones.
+    Can be used a context manager or decorator around `QgsProject.read()` call.
+    """
+
+    def __init__(self, project: QgsProject):
+        self.project = project
+
+    def __enter__(self):
+        bad_layer_handler.clear()
+        # NOTE we should set the bad layer handler only when we need it.
+        # Unfortunately we cannot due to a crash when calling `QgsProject.read()` when we already used this context manager.
+        # The code below is used as documentation for future generations of engineers willing to fix this.
+        # self.project.setBadLayerHandler(bad_layer_handler)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # NOTE we should set the bad layer handler only when we need it.
+        # Unfortunately we cannot due to a crash when calling `QgsProject.read()` when we already used this context manager.
+        # The code below is used as documentation for future generations of engineers willing to fix this.
+
+        # global bad_layer_handler
+        # self.project.setBadLayerHandler(None)
+        pass
+
+    def __call__(self, func):
+        def wrapper(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+
+        return wrapper

--- a/libqfieldsync/utils/qgis.py
+++ b/libqfieldsync/utils/qgis.py
@@ -19,6 +19,7 @@
  ***************************************************************************/
 """
 
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -26,7 +27,7 @@ from typing import List, Optional, Union
 
 from qgis.core import QgsMapLayer, QgsProject
 
-from .bad_layer_handler import bad_layer_handler
+logger = logging.getLogger(__name__)
 
 
 def get_project_title(project: QgsProject) -> str:
@@ -68,8 +69,3 @@ def get_memory_layers(project: QgsProject) -> List[QgsMapLayer]:
 def get_qgis_files_within_dir(dirname: Union[str, Path]) -> List[Path]:
     dirname = Path(dirname)
     return list(dirname.glob("*.qgs")) + list(dirname.glob("*.qgz"))
-
-
-def set_bad_layer_handler(project: QgsProject):
-    bad_layer_handler.clear()
-    project.setBadLayerHandler(bad_layer_handler)


### PR DESCRIPTION
Note there is a commented implementation of it that causes QGIS to crash with core dump. While the proposed implementation is more correct, the pragmatic move is just to set the `QgsProjectBadLayerHandler` globally.