### PR TITLE
Fix regression with basemap creation, which also uses area of interest

### DIFF
--- a/libqfieldsync/offline_converter.py
+++ b/libqfieldsync/offline_converter.py
@@ -112,10 +112,6 @@ class OfflineConverter(QObject):
         self.attachment_dirs = attachment_dirs
         self.dirs_to_copy = dirs_to_copy
 
-        assert (
-            self.area_of_interest_crs.isValid()
-        ), f"Invalid CRS specified for area of interest {area_of_interest_crs}"
-
         self.offliner = offliner
 
         self.offliner.layerProgressUpdated.connect(self._on_offline_editing_next_layer)
@@ -123,6 +119,15 @@ class OfflineConverter(QObject):
         self.offliner.progressUpdated.connect(self._on_offline_editing_task_progress)
 
         self.project_configuration = ProjectConfiguration(project)
+
+        if (
+            self.project_configuration.offline_copy_only_aoi
+            or self.project_configuration.create_base_map
+        ):
+            assert self.area_of_interest.isValid()[0]
+            assert (
+                self.area_of_interest_crs.isValid()
+            ), f"Invalid CRS specified for area of interest {area_of_interest_crs}"
 
     # flake8: noqa: max-complexity: 33
     def convert(self, reload_original_project: bool = True) -> None:
@@ -295,7 +300,7 @@ class OfflineConverter(QObject):
         gpkg_filename = str(self.export_folder.joinpath("data.gpkg"))
         if offline_layers:
             bbox = None
-            if self.area_of_interest.isValid():
+            if self.project_configuration.offline_copy_only_aoi:
                 bbox = QgsCoordinateTransform(
                     QgsCoordinateReferenceSystem(self.area_of_interest_crs),
                     QgsProject.instance().crs(),


### PR DESCRIPTION
A regression slipped into 4.8.0 with regards to basemap creation during cable export.

Long story short, the UI is a bit deceptive and makes it look like the area of interest is only tied to filtering of feature when in fact it's also tied to basemap creation.

The updated logic in this PR fixes the regression, and seems to be easier to read too.