### PR TITLE
When filtering features by bounding box, insure bounding box CRS matches that of the layer

### DIFF
--- a/libqfieldsync/offliners.py
+++ b/libqfieldsync/offliners.py
@@ -87,6 +87,7 @@ class QgisCoreOffliner(BaseOffliner):
         layers: List[QgsMapLayer],
         bbox: Optional[QgsRectangle],
     ) -> bool:
+        project = QgsProject.instance()
         offline_db_path = Path(offline_db_filename).parent
         layer_ids = [layer.id() for layer in layers]
 
@@ -112,7 +113,9 @@ class QgisCoreOffliner(BaseOffliner):
                     # ensure that geometry-less layers do not have selected features that would interfere with the process
                     layer.removeSelection()
                 else:
-                    layer.selectByRect(bbox)
+                    tr = QgsCoordinateTransform(project.crs(), layer.crs(), project)
+                    layer_bbox = tr.transform(bbox)
+                    layer.selectByRect(layer_bbox)
 
                     # If the selection by BBOX did not select anything, make sure we fool `QgsOfflineEditing` something is selected.
                     # Otherwise when `layer.selectedFeatureIds().isEmpty()`, `QgsOfflineEditing` dumps all features.


### PR DESCRIPTION
This fixes a serious issue with QGIS core offliner whereas vector layers with a CRS not matching that of the project CRS can have all features gone missing when packaging cloud projects. 

Fixes https://github.com/opengisch/QField/issues/5094 