### PR TITLE
Temporarily fix the tests with the workaround of using old QGIS images

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        qgis_version: [release-3_16, release-3_22, release-3_28, latest]
+        qgis_version: [release-3_16, release-3_22, release-3_28, final-3_36_1]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
     steps:


### PR DESCRIPTION
Since QGIS images moved to .deb installed QGIS, some stuff have changed and the CI is no longer working properly.

Therefore I have changed the CI not to use `latest`, but the last QGIS image using the old setup.

While this will work for the next few weeks/months, this needs proper fix in the near future.

@dddpt one for you whenever you have time to fix this.