### PR TITLE
Fix "Application path not initialized" warning

### DIFF
--- a/libqfieldsync/layer.py
+++ b/libqfieldsync/layer.py
@@ -129,8 +129,11 @@ class LayerSource(object):
     }
 
     def __init__(
-        self, layer: QgsMapLayer, project: QgsProject = QgsProject.instance()
+        self, layer: QgsMapLayer, project: Optional[QgsProject] = None
     ) -> None:
+        if project is None:
+            project = QgsProject.instance()
+
         self.layer = layer
         self._action = None
         self._cloud_action = None


### PR DESCRIPTION
We should not call QGIS API without a already started `QgsApplication`.
While this is not a problem in QFieldSync, if one runs this in
QFieldCloud within the `qgis` worker.