### PR TITLE
Use QGIS' utility function to detect and copy sidecar files

### DIFF
--- a/libqfieldsync/layer.py
+++ b/libqfieldsync/layer.py
@@ -1016,7 +1016,7 @@ class LayerSource(object):
             suffix = uri_parts[1]
 
         if self.is_file:
-            if hasattr(QgsFileUtils, "sidecarFilesForPath"):
+            if Qgis.QGIS_VERSION_INT > 32200:
                 # QGIS >= 3.22
                 files_to_copy = QgsFileUtils.sidecarFilesForPath(self.filename)
                 files_to_copy.add(self.filename)

--- a/libqfieldsync/layer.py
+++ b/libqfieldsync/layer.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 from qgis.core import (
+    Qgis,
     QgsAttributeEditorField,
     QgsCoordinateTransformContext,
     QgsDataSourceUri,


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/5451 .

Background: until now, libqfieldsync had a limited self-curated detection/handling of sidecar files. The PR retires that code in favor of QGIS' `QgsFileUtils.sidecarFilesForPath(path)` , which does a much better job at returning sidecar files and is future proof (as it relies on individual providers to return sidecar lists, see https://github.com/qgis/QGIS/blob/master/src/core/qgsfileutils.cpp#L457-L475).

Practically speaking, not capturing all sidecar files meant that projects both packaged for USB cable transfer _as well as_ cloud projects could have key files missing and break layers (see above-mentioned issue).
