### PR TITLE
Fixing the files path issue on windows users

### DIFF
--- a/libqfieldsync/utils/qgis.py
+++ b/libqfieldsync/utils/qgis.py
@@ -52,8 +52,7 @@ def make_temp_qgis_file(project: QgsProject) -> str:
     project_backup_dir = tempfile.mkdtemp()
     original_filename = project.fileName()
     backup_filename = os.path.join(project_backup_dir, f"{project.baseName()}.qgs")
-    # NOTE: This makes the conversion of the project mess with the datasource on Windows
-    # project.write(backup_filename)
+    project.write(backup_filename)
     project.setFileName(original_filename)
 
     return backup_filename

--- a/libqfieldsync/utils/qgis.py
+++ b/libqfieldsync/utils/qgis.py
@@ -42,7 +42,7 @@ def open_project(filename: str, filename_to_read: Optional[str] = None) -> bool:
     project = QgsProject.instance()
     project.clear()
 
-    is_success = project.read(filename_to_read or filename)
+    is_success = project.read(filename or filename_to_read)
     project.setFileName(filename)
 
     return is_success

--- a/libqfieldsync/utils/qgis.py
+++ b/libqfieldsync/utils/qgis.py
@@ -52,7 +52,8 @@ def make_temp_qgis_file(project: QgsProject) -> str:
     project_backup_dir = tempfile.mkdtemp()
     original_filename = project.fileName()
     backup_filename = os.path.join(project_backup_dir, f"{project.baseName()}.qgs")
-    project.write(backup_filename)
+    # NOTE: This makes the conversion of the project mess with the datasource on Windows
+    # project.write(backup_filename)
     project.setFileName(original_filename)
 
     return backup_filename


### PR DESCRIPTION
By ensuring the original project is open first, the functionality to convert to offline projects works properly and avoids the package issue for Windows users.