### PR TITLE
Fixing deprecation of setAutoTransaction to setTransactionMode

### DIFF
--- a/libqfieldsync/offline_converter.py
+++ b/libqfieldsync/offline_converter.py
@@ -367,7 +367,11 @@ class OfflineConverter(QObject):
 
     def post_process_offline_layers(self):
         project = QgsProject.instance()
-        project.setEvaluateDefaultValues(False)
+
+        if Qgis.QGIS_VERSION_INT >= 34000:
+            project.setFlag(Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide, False)
+        else:
+            project.setEvaluateDefaultValues(False)
 
         if Qgis.QGIS_VERSION_INT >= 32600:
             project.setTransactionMode(Qgis.TransactionMode.Disabled)

--- a/libqfieldsync/offline_converter.py
+++ b/libqfieldsync/offline_converter.py
@@ -368,7 +368,11 @@ class OfflineConverter(QObject):
     def post_process_offline_layers(self):
         project = QgsProject.instance()
         project.setEvaluateDefaultValues(False)
-        project.setAutoTransaction(False)
+
+        if Qgis.QGIS_VERSION_INT >= 32600:
+            project.setTransactionMode(Qgis.TransactionMode.Disabled)
+        else:
+            project.setAutoTransaction(False)
 
         # check if value relations point to offline layers and adjust if necessary
         for e_layer in project.mapLayers().values():


### PR DESCRIPTION
This fixes the warning of deprecation of the `setAutoTransaction`

Reported on https://github.com/opengisch/qfieldsync/issues/612