### PR TITLE
Fix typing for GDAL 3.10.0+

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -6,13 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
       - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
+        uses: actions/setup-python@v5
+
       - name: Install pipenv
         run: pip install pipenv
+
       - name: Check code formatting
         run: |
           pipenv install pre_commit
@@ -26,9 +27,10 @@ jobs:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
+
       - name: Run tests
         run: |
           docker compose -f .docker/docker-compose.yml run qgis /usr/src/.docker/run-docker-tests.sh
@@ -36,17 +38,18 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
             submodules: recursive
+
         - name: Setup Python
-          uses: actions/setup-python@v4
-          with:
-            python-version: 3.8
-            cache: 'pip'
+          uses: actions/setup-python@v5
+
         - name: Install toolchain
           run: pip install build
+
         - name: Package with build
           run:  python -m build
+
         - name: Install with pip
           run: pip install .

--- a/libqfieldsync/offliners.py
+++ b/libqfieldsync/offliners.py
@@ -2,9 +2,9 @@ import hashlib
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
-from typing import List, NamedTuple, Optional
+from typing import List, NamedTuple, Optional, NewType
 
-from osgeo import ogr, osr
+from osgeo import gdal, ogr, osr
 from PyQt5.QtCore import QFileInfo, QVariant
 from qgis.core import (
     Qgis,
@@ -24,6 +24,12 @@ from qgis.core import (
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 
 from .utils.logger import logger
+
+# In GDAL 3.10.0 the return value of `ogr.CreateDataSource` changed from `ogr.DataSource` to `gdal.Dataset`.
+if gdal.VersionInfo() > "3010000":
+    OgrDataset = NewType("OgrDataset", gdal.Dataset)  # type: ignore
+else:
+    OgrDataset = NewType("OgrDataset", ogr.DataSource)  # type: ignore
 
 FID_NULL = -4294967296
 
@@ -219,7 +225,7 @@ class PythonMiniOffliner(BaseOffliner):
         return data
 
     def create_layer(
-        self, layer: QgsVectorLayer, data_source: ogr.DataSource, offline_gpkg_path: str
+        self, layer: QgsVectorLayer, data_source: OgrDataset, offline_gpkg_path: str
     ) -> None:
         """
         Will create a new layer for ``layer`` in the GeoPackage specified as ``data_source`` which is stored at ``offline_gpkg_path``.
@@ -270,7 +276,7 @@ class PythonMiniOffliner(BaseOffliner):
     def convert_to_offline_layer(
         self,
         layer: QgsVectorLayer,
-        data_source: ogr.DataSource,
+        data_source: OgrDataset,
         offline_gpkg_path: str,
         feature_request: QgsFeatureRequest = QgsFeatureRequest(),
     ) -> str:


### PR DESCRIPTION
In GDAL 3.10.0 the return value of `ogr.CreateDataSource` changed from `ogr.DataSource` to `gdal.Dataset`.

Experienced by Windows users using OSGeo4W: https://github.com/jef-n/OSGeo4W/commit/5469ac4aadc47cab8f535395e6e92c56324d72ef
And announced here: https://github.com/OSGeo/gdal/blob/v3.10.0/NEWS.md

Fixes https://github.com/opengisch/qfieldsync/issues/633