### PR TITLE
Add isort pre commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,10 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: []
+
+  # Sort imports alphabetically
+  - repo: https://github.com/PyCQA/isort
+    rev: 6.0.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]

--- a/libqfieldsync/offline_converter.py
+++ b/libqfieldsync/offline_converter.py
@@ -34,6 +34,7 @@ from qgis.core import (
     QgsEditorWidgetSetup,
     QgsField,
     QgsFields,
+    QgsLayerTreeGroup,
     QgsMapLayer,
     QgsPolygon,
     QgsProcessingContext,
@@ -42,7 +43,6 @@ from qgis.core import (
     QgsRasterLayer,
     QgsValueRelationFieldFormatter,
     QgsVectorLayer,
-    QgsLayerTreeGroup,
 )
 from qgis.PyQt.QtCore import QCoreApplication, QObject, pyqtSignal
 

--- a/libqfieldsync/offliners.py
+++ b/libqfieldsync/offliners.py
@@ -2,7 +2,7 @@ import hashlib
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
-from typing import List, NamedTuple, Optional, NewType
+from typing import List, NamedTuple, NewType, Optional
 
 from osgeo import gdal, ogr, osr
 from PyQt5.QtCore import QFileInfo, QVariant

--- a/libqfieldsync/project_checker.py
+++ b/libqfieldsync/project_checker.py
@@ -9,7 +9,7 @@ from qgis.PyQt.QtCore import QObject
 
 from libqfieldsync.layer import LayerSource, SyncAction, UnsupportedPrimaryKeyError
 from libqfieldsync.project import ProjectConfiguration, ProjectProperties
-from libqfieldsync.utils.file_utils import isascii, is_valid_filepath
+from libqfieldsync.utils.file_utils import is_valid_filepath, isascii
 
 from .offline_converter import ExportType
 


### PR DESCRIPTION
This PR adds `isort` to pre-commit hooks configuration.

As well as reformat existing code using isort.