### PR TITLE
The layers outside the project directory should be check only on cloud projects

### DIFF
--- a/libqfieldsync/project_checker.py
+++ b/libqfieldsync/project_checker.py
@@ -112,7 +112,7 @@ class ProjectChecker:
             {
                 "type": Feedback.Level.WARNING,
                 "fn": self.check_external_layers,
-                "scope": None,
+                "scope": ExportType.Cloud,
             },
             {
                 "type": Feedback.Level.WARNING,


### PR DESCRIPTION
When packaging a project to work offline (no cloud project), all project layers are packaged regardless of the layer's source file location. However, in QFieldCloud projects, if new layers are added outside the project's home location, their sources can't be uploaded to the cloud. This leads to improper packaging jobs in the cloud.

Motivated by this issue report: https://github.com/opengisch/qfieldsync/issues/645