### PR TITLE
clean(basemap): use project's tile size when generating basemap

### DIFF
--- a/libqfieldsync/offline_converter.py
+++ b/libqfieldsync/offline_converter.py
@@ -661,7 +661,7 @@ class OfflineConverter(QObject):
             "EXTENT": extent,
             "ZOOM_MIN": self.project_configuration.base_map_tiles_min_zoom_level,
             "ZOOM_MAX": self.project_configuration.base_map_tiles_max_zoom_level,
-            "TILE_SIZE": 256,
+            "TILE_SIZE": self.project_configuration.base_map_tile_size,
             "OUTPUT_FILE": str(basemap_export_path),
         }
 

--- a/libqfieldsync/project.py
+++ b/libqfieldsync/project.py
@@ -10,7 +10,6 @@ class ProjectProperties(object):
     BASE_MAP_THEME = "/baseMapTheme"
     BASE_MAP_LAYER = "/baseMapLayer"
     BASE_MAP_TILE_SIZE = "/baseMapTileSize"
-    BASE_MAP_MUPP = "/baseMapMupp"
     BASE_MAP_TILES_MIN_ZOOM_LEVEL = "/baseMapTilesMinZoomLevel"
     BASE_MAP_TILES_MAX_ZOOM_LEVEL = "/baseMapTilesMaxZoomLevel"
     OFFLINE_COPY_ONLY_AOI = "/offlineCopyOnlyAoi"
@@ -246,19 +245,6 @@ class ProjectConfiguration(object):
     def base_map_tile_size(self, value):
         self.project.writeEntry(
             "qfieldsync", ProjectProperties.BASE_MAP_TILE_SIZE, value
-        )
-
-    @property
-    def base_map_mupp(self):
-        base_map_mupp, _ = self.project.readDoubleEntry(
-            "qfieldsync", ProjectProperties.BASE_MAP_MUPP, 10.0
-        )
-        return base_map_mupp
-
-    @base_map_mupp.setter
-    def base_map_mupp(self, value):
-        self.project.writeEntryDouble(
-            "qfieldsync", ProjectProperties.BASE_MAP_MUPP, value
         )
 
     @property

--- a/tests/data/geometryless_project/project.qgs
+++ b/tests/data/geometryless_project/project.qgs
@@ -1165,7 +1165,6 @@
     <qfieldsync>
       <areaOfInterest type="QString"></areaOfInterest>
       <areaOfInterestCrs type="QString"></areaOfInterestCrs>
-      <baseMapMupp type="double">10</baseMapMupp>
       <baseMapTheme type="QString"></baseMapTheme>
       <baseMapTileSize type="int">1024</baseMapTileSize>
       <baseMapType type="QString">singleLayer</baseMapType>

--- a/tests/data/pk_project/project.qgs
+++ b/tests/data/pk_project/project.qgs
@@ -546,7 +546,6 @@
       <ProjectionsEnabled type="int">1</ProjectionsEnabled>
     </SpatialRefSys>
     <qfieldsync>
-      <baseMapMupp type="double">10</baseMapMupp>
       <baseMapTheme type="QString"></baseMapTheme>
       <baseMapTileSize type="int">1024</baseMapTileSize>
       <baseMapType type="QString">singleLayer</baseMapType>


### PR DESCRIPTION
This PR intends to use the project's basemap tile size as a parameter when calling the underlying QGIS processing algorithm used to generate mbtiles.