### PR TITLE
fix: do not allow "Directly access datasource" on QFieldCloud packaging actions for file based layers that are not readonly

### DIFF
--- a/libqfieldsync/layer.py
+++ b/libqfieldsync/layer.py
@@ -804,7 +804,7 @@ class LayerSource(object):
     def available_cloud_actions(self):
         actions = []
 
-        if self.is_virtual:
+        if self.is_virtual or self.is_localized_path:
             actions.append(
                 (
                     SyncAction.NO_ACTION,
@@ -813,6 +813,13 @@ class LayerSource(object):
                     ),
                 )
             )
+            actions.append(
+                (
+                    SyncAction.REMOVE,
+                    QCoreApplication.translate("LayerAction", "Remove from project"),
+                )
+            )
+
             return actions
 
         if self.layer.type() == QgsMapLayer.VectorLayer:
@@ -825,16 +832,7 @@ class LayerSource(object):
             )
 
             # only online layers support direct access, e.g. PostGIS or WFS
-            if not (self.is_file and not self.is_localized_path):
-                actions.append(
-                    (
-                        SyncAction.NO_ACTION,
-                        QCoreApplication.translate(
-                            "LayerAction", "Directly access data source"
-                        ),
-                    )
-                )
-            elif self.is_file and not self.is_localized_path:
+            if not self.is_file or self.layer.readOnly():
                 actions.append(
                     (
                         SyncAction.NO_ACTION,


### PR DESCRIPTION
When configuring QFieldCloud packaging options, we might get the confusing scenario of configuring a file based vector layer (gpkg) with "Directly access datasource" which will make the layer editable on QField, but never synchronizable back to QFieldCloud. This is bad and may cause potential data loss.

So we can just disable this option in a way, that "Directly access datasource" is available for :

1) non-file based layers (virtual, postgis, wfs etc)
2) file based layers that are in read-only mode (readonly gpkg)

In this PR I also enabled removing localized and virtual layers from the project.