### PR TITLE
Add a project-level setting to enable QField feature form's wizard mode

### DIFF
--- a/libqfieldsync/project.py
+++ b/libqfieldsync/project.py
@@ -34,6 +34,7 @@ class ProjectProperties:
     STAMPING_HORIZONTAL_ALIGNMENT = "/stampingHorizontalAlignment"
     STAMPING_IMAGE_DECORATION = "/stampingImageDecoration"
     STAMPING_DETAILS_TEMPLATE = "/stampingDetailsTemplate"
+    FEATURE_FORM_WIZARD_MODE_ENABLED = "/featureFormWizardModeEnabled"
 
     class BaseMapType:
         def __init__(self):
@@ -268,6 +269,19 @@ class ProjectConfiguration:
     @force_stamping.setter
     def force_stamping(self, value):
         self.project.writeEntry("qfieldsync", ProjectProperties.FORCE_STAMPING, value)
+
+    @property
+    def feature_form_wizard_mode_enabled(self):
+        feature_form_wizard_mode_enabled, _ = self.project.readBoolEntry(
+            "qfieldsync", ProjectProperties.FEATURE_FORM_WIZARD_MODE_ENABLED, False
+        )
+        return feature_form_wizard_mode_enabled
+
+    @feature_form_wizard_mode_enabled.setter
+    def feature_form_wizard_mode_enabled(self, value):
+        self.project.writeEntry(
+            "qfieldsync", ProjectProperties.FEATURE_FORM_WIZARD_MODE_ENABLED, value
+        )
 
     @property
     def map_themes_active_layer(self):


### PR DESCRIPTION
Adding a new property to be used by QFieldSync to toggle QField's feature form wizard mode.

Context: https://github.com/opengisch/QField/pull/7316