### PR TITLE
Fix bad project title when packaging cloud project using the optimized packager

### DIFF
--- a/libqfieldsync/offliners.py
+++ b/libqfieldsync/offliners.py
@@ -477,8 +477,6 @@ class PythonMiniOffliner(BaseOffliner):
             if not project_title:
                 project_title = QFileInfo(project.fileName()).baseName()
 
-            project_title += f"{project_title} (offline)"
-
         project.setTitle(project_title)
 
         project.writeEntry(


### PR DESCRIPTION
Two issues:
- the title itself is repeated (due to a bogus += instead of =)
- the title has a technical and unwelcome "(offline)" suffix

The result:
<img width="474" height="368" alt="Screenshot From 2026-04-21 08-56-21" src="https://github.com/user-attachments/assets/7806b8d4-a48a-4f90-acd2-f3f139076b47" />

The fix: 
- this PR

Re the suffix, the older packager that relies on QGIS did not append "(offline)" and IMHO is the right thing to do. We use the project title in the QField UI in a few places, including the project plugin permission, and if I set a beautiful project title in my project metadata, I want it to stay the same :)