### PR TITLE
ci: configure dependabot to propose monthly bumps of github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
See : https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions

This should make dependabot automatically open mergeable PRs on a monthly basis, so that we regularly bump the versions of the used GitHub Actions.

See [an example of such a PR](https://github.com/geotribu/qchat/pull/59) -> all you need is merge.

IMO this is good balance between reduced noise, minimal maintenance efforts and staying up-to-date with our GitHub Actions,  
Maybe there are some GH settings to change regarding dependabot, though I'm not sure.

ping @suricactus @nirvn @m-kuhn 