### PR TITLE
Bump python min version to 3.9 and update tools

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-ignore = E501, F401, W503
-max-line-length = 120
-max-complexity = 30

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,26 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-      - id: trailing-whitespace
+      - id: check-ast
+        files: '.*\.py$'
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-illegal-windows-names
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: destroyed-symlinks
       - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: forbid-new-submodules
       - id: mixed-line-ending
         args:
           - '--fix=lf'
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
 
   # Lint and format
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,9 +42,11 @@ repos:
       # Run the formatter.
       - id: ruff-format
 
-  # Static type-checking with mypy
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.17.1'
-    hooks:
-      - id: mypy
-        additional_dependencies: []
+  # Disabled dead code because most of the code in `libqfieldsync` is not directly used here, but called from QFieldCloud and QFieldSync.
+  # Kept because we should run it once in a while to check for dead code and remove it.
+  # - repo: https://github.com/asottile/dead
+  #   rev: v2.1.0
+  #   hooks:
+  #   - id: dead
+  #     # Exclude utils directory as it contains code used by QFieldCloud and QFieldSync, but not used by the library itself.
+  #     args: [--exclude, 'utils/.*\.py$']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,12 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
 
+  - repo: https://github.com/pycqa/flake8
+    rev: '7.3.0'
+    hooks:
+    -   id: flake8
+        additional_dependencies: [flake8-pyproject, flake8-clean-block, flake8-if-expr]
+
   # Lint and format
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,11 +33,11 @@ repos:
   # Lint and format
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.11
+    rev: v0.15.11
     hooks:
       # Run the linter.
       - id: ruff
-        args: [ "--select", "I", "--fix" ]
+        args: [ --fix ]
 
       # Run the formatter.
       - id: ruff-format

--- a/libqfieldsync/layer.py
+++ b/libqfieldsync/layer.py
@@ -1325,7 +1325,7 @@ class LayerSource:
                 else:
                     new_source = os.path.join(target_path, file_name)
                     if suffix != "":
-                        new_source = "{}|{}".format(new_source, suffix)  # noqa: UP032
+                        new_source = "{}|{}".format(new_source, suffix)
 
             self._change_data_source(new_source)
 
@@ -1375,7 +1375,7 @@ class LayerSource:
             if new_source == "":
                 new_source = os.path.join(target_path, file_name)
                 if suffix != "":
-                    new_source = "{}|{}".format(new_source, suffix)  # noqa: UP032
+                    new_source = "{}|{}".format(new_source, suffix)
 
         layer_subset_string = self.layer.subsetString()
         if new_source == "":

--- a/libqfieldsync/layer.py
+++ b/libqfieldsync/layer.py
@@ -33,46 +33,6 @@ class ExpectedVectorLayerError(Exception): ...
 class UnsupportedPrimaryKeyError(Exception): ...
 
 
-# When copying files, if any of the extension in any of the groups is found,
-# other files with the same extension in the same folder will be copied as well.
-file_extension_groups = [
-    [
-        ".shp",
-        ".shx",
-        ".dbf",
-        ".sbx",
-        ".sbn",
-        ".shp.xml",
-        ".prj",
-        ".cpg",
-        ".qpj",
-        ".qix",
-    ],
-    [".tab", ".dat", ".map", ".xls", ".xlsx", ".id", ".ind", ".wks", ".dbf"],
-    [".png", ".pgw"],
-    [".jpg", ".jgw"],
-    [".tif", ".tfw", ".wld"],
-]
-
-
-def get_file_extension_group(filename):
-    """
-    Return the basename and an extension group (if applicable)
-
-    Examples:
-         airports.shp -> 'airport', ['.shp', '.shx', '.dbf', '.sbx', '.sbn', '.shp.xml']
-         forests.gpkg -> 'forests', ['.gpkg']
-
-    """
-    for group in file_extension_groups:
-        for extension in group:
-            if filename.endswith(extension):
-                return filename[: -len(extension)], group
-
-    basename, ext = os.path.splitext(filename)
-    return basename, [ext]
-
-
 class SyncAction:
     """Enumeration of sync actions"""
 
@@ -914,10 +874,6 @@ class LayerSource:
     def is_supported(self):
         # ecw raster
         return not self.layer.source().endswith("ecw")
-
-    @property
-    def can_lock_geometry(self):
-        return self.layer.type() == QgsMapLayer.LayerType.VectorLayer
 
     @property
     def value_map_button_interface_threshold(self):

--- a/libqfieldsync/layer.py
+++ b/libqfieldsync/layer.py
@@ -3,7 +3,7 @@ import os
 import re
 import shutil
 from enum import Enum
-from typing import ClassVar, Dict, List, Optional
+from typing import ClassVar, Optional
 
 from qgis.core import (
     QgsAttributeEditorField,
@@ -80,7 +80,7 @@ class LayerSource:
         PackagePreventionReason.UNSUPPORTED_DATASOURCE,
     )
 
-    ATTACHMENT_EXPRESSIONS: ClassVar[Dict[AttachmentType, str]] = {
+    ATTACHMENT_EXPRESSIONS: ClassVar[dict[AttachmentType, str]] = {
         AttachmentType.FILE: "'files/{layername}_' || format_date(now(),'yyyyMMddhhmmsszzz') || '_{{filename}}'",
         AttachmentType.IMAGE: "'DCIM/{layername}_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.{{extension}}'",
         AttachmentType.WEB: "",
@@ -645,7 +645,7 @@ class LayerSource:
         resource_type = ews.config().get("DocumentViewer", 0)
         return self.get_attachment_type_by_int_value(resource_type)
 
-    def get_attachment_fields(self) -> Dict[str, AttachmentType]:
+    def get_attachment_fields(self) -> dict[str, AttachmentType]:
         if self.layer.type() != QgsMapLayer.LayerType.VectorLayer:
             return {}
 
@@ -1138,7 +1138,7 @@ class LayerSource:
         )
 
     @property
-    def metadata(self) -> Dict:
+    def metadata(self) -> dict:
         if self.provider_metadata is None:
             return {}
 
@@ -1196,7 +1196,7 @@ class LayerSource:
     @property
     def package_prevention_reasons(
         self,
-    ) -> List["LayerSource.PackagePreventionReason"]:
+    ) -> list["LayerSource.PackagePreventionReason"]:
         reasons = []
 
         # remove unsupported layers from the packaged project

--- a/libqfieldsync/layer.py
+++ b/libqfieldsync/layer.py
@@ -68,6 +68,7 @@ def get_file_extension_group(filename):
         for extension in group:
             if filename.endswith(extension):
                 return filename[: -len(extension)], group
+
     basename, ext = os.path.splitext(filename)
     return basename, [ext]
 
@@ -260,6 +261,7 @@ class LayerSource:
             self._feature_deletion_locked_expression = self.layer.customProperty(
                 "QFieldSync/feature_deletion_locked_expression", ""
             )
+
         self._allow_value_relation_feature_addition = self.layer.customProperty(
             "QFieldSync/allow_value_relation_feature_addition", False
         )
@@ -500,6 +502,7 @@ class LayerSource:
             self.layer.setCustomProperty("QFieldSync/is_feature_addition_locked", True)
         else:
             self.layer.removeCustomProperty("QFieldSync/is_feature_addition_locked")
+
         if self.is_feature_addition_locked_expression_active:
             self.layer.setCustomProperty(
                 "QFieldSync/is_feature_addition_locked_expression_active", True
@@ -508,6 +511,7 @@ class LayerSource:
             self.layer.removeCustomProperty(
                 "QFieldSync/is_feature_addition_locked_expression_active"
             )
+
         self.layer.setCustomProperty(
             "QFieldSync/feature_addition_locked_expression",
             self.feature_addition_locked_expression,
@@ -516,6 +520,7 @@ class LayerSource:
             self.layer.setCustomProperty("QFieldSync/is_attribute_editing_locked", True)
         else:
             self.layer.removeCustomProperty("QFieldSync/is_attribute_editing_locked")
+
         if self.is_attribute_editing_locked_expression_active:
             self.layer.setCustomProperty(
                 "QFieldSync/is_attribute_editing_locked_expression_active", True
@@ -524,6 +529,7 @@ class LayerSource:
             self.layer.removeCustomProperty(
                 "QFieldSync/is_attribute_editing_locked_expression_active"
             )
+
         self.layer.setCustomProperty(
             "QFieldSync/attribute_editing_locked_expression",
             self.attribute_editing_locked_expression,
@@ -532,6 +538,7 @@ class LayerSource:
             self.layer.setCustomProperty("QFieldSync/is_geometry_editing_locked", True)
         else:
             self.layer.removeCustomProperty("QFieldSync/is_geometry_editing_locked")
+
         if self.is_geometry_editing_locked_expression_active:
             self.layer.setCustomProperty(
                 "QFieldSync/is_geometry_editing_locked_expression_active", True
@@ -540,6 +547,7 @@ class LayerSource:
             self.layer.removeCustomProperty(
                 "QFieldSync/is_geometry_editing_locked_expression_active"
             )
+
         self.layer.setCustomProperty(
             "QFieldSync/geometry_editing_locked_expression",
             self.geometry_editing_locked_expression,
@@ -548,6 +556,7 @@ class LayerSource:
             self.layer.setCustomProperty("QFieldSync/is_feature_deletion_locked", True)
         else:
             self.layer.removeCustomProperty("QFieldSync/is_feature_deletion_locked")
+
         if self.is_feature_deletion_locked_expression_active:
             self.layer.setCustomProperty(
                 "QFieldSync/is_feature_deletion_locked_expression_active", True
@@ -556,6 +565,7 @@ class LayerSource:
             self.layer.removeCustomProperty(
                 "QFieldSync/is_feature_deletion_locked_expression_active"
             )
+
         self.layer.setCustomProperty(
             "QFieldSync/feature_deletion_locked_expression",
             self.feature_deletion_locked_expression,
@@ -574,6 +584,7 @@ class LayerSource:
             self.layer.setCustomProperty("QFieldSync/tracking_session_active", True)
         else:
             self.layer.removeCustomProperty("QFieldSync/tracking_session_active")
+
         if self.tracking_time_requirement_active:
             self.layer.setCustomProperty(
                 "QFieldSync/tracking_time_requirement_active", True
@@ -582,6 +593,7 @@ class LayerSource:
             self.layer.removeCustomProperty(
                 "QFieldSync/tracking_time_requirement_active"
             )
+
         self.layer.setCustomProperty(
             "QFieldSync/tracking_time_requirement_interval_seconds",
             self.tracking_time_requirement_interval_seconds,
@@ -594,6 +606,7 @@ class LayerSource:
             self.layer.removeCustomProperty(
                 "QFieldSync/tracking_distance_requirement_active"
             )
+
         self.layer.setCustomProperty(
             "QFieldSync/tracking_distance_requirement_minimum_meters",
             self.tracking_distance_requirement_minimum_meters,
@@ -606,6 +619,7 @@ class LayerSource:
             self.layer.removeCustomProperty(
                 "QFieldSync/tracking_sensor_data_requirement_active"
             )
+
         if self.tracking_all_requirements_active:
             self.layer.setCustomProperty(
                 "QFieldSync/tracking_all_requirements_active", True
@@ -614,6 +628,7 @@ class LayerSource:
             self.layer.removeCustomProperty(
                 "QFieldSync/tracking_all_requirements_active"
             )
+
         if self.tracking_erroneous_distance_safeguard_active:
             self.layer.setCustomProperty(
                 "QFieldSync/tracking_erroneous_distance_safeguard_active", True
@@ -622,6 +637,7 @@ class LayerSource:
             self.layer.removeCustomProperty(
                 "QFieldSync/tracking_erroneous_distance_safeguard_active"
             )
+
         self.layer.setCustomProperty(
             "QFieldSync/tracking_erroneous_distance_safeguard_maximum_meters",
             self.tracking_erroneous_distance_safeguard_maximum_meters,
@@ -1149,6 +1165,7 @@ class LayerSource:
             return QCoreApplication.translate(
                 "DataSourceWarning", "ECW layers are not supported by QField."
             )
+
         return None
 
     @property
@@ -1355,6 +1372,7 @@ class LayerSource:
                         new_source = "{}|{}".format(new_source, suffix)  # noqa: UP032
 
             self._change_data_source(new_source)
+
         return copied_files
 
     def convert_to_gpkg(self, target_path):  # noqa: PLR0912, PLR0915
@@ -1422,6 +1440,7 @@ class LayerSource:
             source_layer_joins = source_layer.vectorJoins()
             for join in source_layer_joins:
                 source_layer.removeJoin(join.joinLayerId())
+
             fields = source_layer.fields()
             virtual_field_count = 0
             for i in range(len(fields)):
@@ -1443,6 +1462,7 @@ class LayerSource:
 
             if error != QgsVectorFileWriter.WriterError.NoError:
                 return None
+
             if returned_dest_file:
                 new_source = returned_dest_file
             else:

--- a/libqfieldsync/offline_converter.py
+++ b/libqfieldsync/offline_converter.py
@@ -91,7 +91,6 @@ class ExportType(Enum):
 
 
 class OfflineConverter(QObject):
-    progress_stopped = pyqtSignal()
     warning = pyqtSignal(str, str)
     task_progress_updated = pyqtSignal(int, int)
     total_progress_updated = pyqtSignal(int, int, str)

--- a/libqfieldsync/offline_converter.py
+++ b/libqfieldsync/offline_converter.py
@@ -295,19 +295,23 @@ class OfflineConverter(QObject):
                 # do not attempt to package the layer
                 continue
 
+            if hasattr(layer, "fields"):
+                layer_fields = layer.fields()
+            else:
+                layer_fields = None
+
             layer_data: LayerData = {
                 "id": layer.id(),
                 "name": layer.name(),
                 "type": layer.type(),
                 "source": layer.source(),
-                "fields": layer.fields() if hasattr(layer, "fields") else None,
+                "fields": layer_fields,
             }
 
-            layer_action = (
-                layer_source.action
-                if self.export_type == ExportType.Cable
-                else layer_source.cloud_action
-            )
+            if self.export_type == ExportType.Cable:
+                layer_action = layer_source.action
+            else:
+                layer_action = layer_source.cloud_action
 
             if layer.isValid() and layer.type() == QgsMapLayer.LayerType.VectorLayer:
                 if layer_source.pk_attr_name:

--- a/libqfieldsync/offline_converter.py
+++ b/libqfieldsync/offline_converter.py
@@ -20,7 +20,7 @@
 import tempfile
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional, TypedDict, Union, cast
+from typing import Optional, TypedDict, Union, cast
 
 from qgis.core import (
     Qgis,
@@ -106,11 +106,11 @@ class OfflineConverter(QObject):
         export_filename: str,
         area_of_interest_wkt: str,
         area_of_interest_crs: Union[str, QgsCoordinateReferenceSystem],
-        attachment_dirs: List[str],
+        attachment_dirs: list[str],
         offliner: BaseOffliner,
         export_type: Optional[ExportType] = None,
         create_basemap: bool = True,
-        dirs_to_copy: Optional[Dict[str, bool]] = None,
+        dirs_to_copy: Optional[dict[str, bool]] = None,
         export_title: str = "",
     ) -> None:
         # NOTE: while it will be much more readable to pass `export_type` parameter to have a default value of `ExportType.Cable`,
@@ -122,8 +122,8 @@ class OfflineConverter(QObject):
         super().__init__(parent=None)
         self.__max_task_progress = 0
         self.__convertor_progress = None  # for processing feedback
-        self.__layer_data_by_id: Dict[str, LayerData] = {}
-        self.__offline_layer_names: List[str] = []
+        self.__layer_data_by_id: dict[str, LayerData] = {}
+        self.__offline_layer_names: list[str] = []
 
         # elipsis workaround
         self.trUtf8 = self.tr
@@ -178,7 +178,7 @@ class OfflineConverter(QObject):
 
             self.total_progress_updated.emit(100, 100, self.tr("Finished"))
 
-    def _get_additional_project_files(self, project: QgsProject) -> List[str]:
+    def _get_additional_project_files(self, project: QgsProject) -> list[str]:
         original_project_path = Path(self.original_filename).parent
         additional_project_files = []
 
@@ -255,8 +255,8 @@ class OfflineConverter(QObject):
         self._export_filename.parent.mkdir(parents=True, exist_ok=True)
         self.total_progress_updated.emit(0, 100, self.trUtf8("Converting project…"))
 
-        project_layers: List[QgsMapLayer] = list(project.mapLayers().values())
-        offline_layers: List[QgsMapLayer] = []
+        project_layers: list[QgsMapLayer] = list(project.mapLayers().values())
+        offline_layers: list[QgsMapLayer] = []
         copied_files = []
 
         if self.create_basemap and self.project_configuration.create_base_map:

--- a/libqfieldsync/offliners.py
+++ b/libqfieldsync/offliners.py
@@ -3,7 +3,7 @@ import os
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, NamedTuple, NewType, Optional
+from typing import NamedTuple, NewType, Optional
 
 from osgeo import gdal, ogr, osr
 from qgis.core import (
@@ -62,7 +62,7 @@ class BaseOffliner(QObject):
     def convert_to_offline(
         self,
         offline_db_filename: str,
-        layers: List[QgsMapLayer],
+        layers: list[QgsMapLayer],
         bbox: Optional[QgsRectangle],
         exported_project_title: str = "",
     ) -> bool:
@@ -98,7 +98,7 @@ class QgisCoreOffliner(BaseOffliner):
     def convert_to_offline(
         self,
         offline_db_filename: str,
-        layers: List[QgsMapLayer],
+        layers: list[QgsMapLayer],
         bbox: Optional[QgsRectangle],
         exported_project_title: str = "",
     ) -> bool:
@@ -178,7 +178,7 @@ class PythonMiniOffliner(BaseOffliner):
     def convert_to_offline(
         self,
         offline_db_filename: str,
-        layers: List[QgsMapLayer],
+        layers: list[QgsMapLayer],
         bbox: Optional[QgsRectangle],
         exported_project_title: str = "",
     ) -> bool:
@@ -393,7 +393,7 @@ class PythonMiniOffliner(BaseOffliner):
     def _convert_to_offline_project(
         self,
         offline_gpkg_path: str,
-        offline_layers: Optional[List[QgsMapLayer]],
+        offline_layers: Optional[list[QgsMapLayer]],
         bbox: Optional[QgsRectangle],
         exported_project_title: str = "",
     ) -> None:
@@ -487,8 +487,8 @@ class PythonMiniOffliner(BaseOffliner):
         )
 
     def _get_filters_mapping(
-        self, datasource_mapping: Dict[str, List[LayerInfo]]
-    ) -> Dict[str, str]:
+        self, datasource_mapping: dict[str, list[LayerInfo]]
+    ) -> dict[str, str]:
         """Get mapping of filter strings to be applied for each datasource. If no filters to be applied, the value will be an empty string."""
         filters_by_datasource = {}
 
@@ -509,8 +509,8 @@ class PythonMiniOffliner(BaseOffliner):
     def _get_datasource_mapping(
         self,
         project: QgsProject,
-        offline_layers: Optional[List[QgsMapLayer]],
-    ) -> Dict[str, List[LayerInfo]]:
+        offline_layers: Optional[list[QgsMapLayer]],
+    ) -> dict[str, list[LayerInfo]]:
         """
         Create a dict of data sources (tables/files) to a list of layers that consume data from them.
 

--- a/libqfieldsync/offliners.py
+++ b/libqfieldsync/offliners.py
@@ -84,15 +84,15 @@ class QgisCoreOffliner(BaseOffliner):
         # Check https://api.qgis.org/api/3.14/classQgsOfflineEditing.html#a59d2ebed32704f655868951eba6ef52e for more documentation of these signals
         # NOTE directly connecting the slot like `self.offliner.progress_mode_set.connect(self.progress_mode_set)` raises typing error
         self.qgs_offline_editing.layerProgressUpdated.connect(
-            lambda progress, layer_idx: self.layer_progress_updated.emit(
+            lambda progress, layer_idx: self.layer_progress_updated.emit(  # noqa: PLW0108
                 progress, layer_idx
             )
         )
         self.qgs_offline_editing.progressModeSet.connect(
-            lambda mode, maximum: self.progress_mode_set.emit(mode, maximum)
+            lambda mode, maximum: self.progress_mode_set.emit(mode, maximum)  # noqa: PLW0108
         )
         self.qgs_offline_editing.progressUpdated.connect(
-            lambda progress: self.progress_updated.emit(progress)
+            lambda progress: self.progress_updated.emit(progress)  # noqa: PLW0108
         )
 
     def convert_to_offline(

--- a/libqfieldsync/offliners.py
+++ b/libqfieldsync/offliners.py
@@ -84,15 +84,15 @@ class QgisCoreOffliner(BaseOffliner):
         # Check https://api.qgis.org/api/3.14/classQgsOfflineEditing.html#a59d2ebed32704f655868951eba6ef52e for more documentation of these signals
         # NOTE directly connecting the slot like `self.offliner.progress_mode_set.connect(self.progress_mode_set)` raises typing error
         self.qgs_offline_editing.layerProgressUpdated.connect(
-            lambda progress, layer_idx: self.layer_progress_updated.emit(  # noqa: PLW0108
+            lambda progress, layer_idx: self.layer_progress_updated.emit(
                 progress, layer_idx
             )
         )
         self.qgs_offline_editing.progressModeSet.connect(
-            lambda mode, maximum: self.progress_mode_set.emit(mode, maximum)  # noqa: PLW0108
+            lambda mode, maximum: self.progress_mode_set.emit(mode, maximum)
         )
         self.qgs_offline_editing.progressUpdated.connect(
-            lambda progress: self.progress_updated.emit(progress)  # noqa: PLW0108
+            lambda progress: self.progress_updated.emit(progress)
         )
 
     def convert_to_offline(

--- a/libqfieldsync/offliners.py
+++ b/libqfieldsync/offliners.py
@@ -222,6 +222,7 @@ class PythonMiniOffliner(BaseOffliner):
         ogr_field = ogr.FieldDefn(field.name(), ogr_type)
         if ogr_sub_type != ogr.OFSTNone:
             ogr_field.SetSubType(ogr_sub_type)
+
         ogr_field.SetWidth(ogr_width)
 
         return ogr_field
@@ -526,7 +527,9 @@ class PythonMiniOffliner(BaseOffliner):
                 reason = ""
                 if layer.dataProvider():
                     reason = layer.dataProvider().error()
+
                 logger.info(f"Skipping layer {layer.name()} :: invalid ({reason})")
+
                 continue
 
             if offline_layers is not None and layer not in offline_layers:

--- a/libqfieldsync/project.py
+++ b/libqfieldsync/project.py
@@ -179,6 +179,7 @@ class ProjectConfiguration:
             ProjectProperties.InitialMapMode.DIGITIZE,
         ):
             return initial_map_mode
+
         return ProjectProperties.InitialMapMode.BROWSE
 
     @initial_map_mode.setter

--- a/libqfieldsync/project_checker.py
+++ b/libqfieldsync/project_checker.py
@@ -1,8 +1,7 @@
-import sys
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Optional, TypedDict
 
 from qgis.core import Qgis, QgsMapLayer, QgsProject
 from qgis.PyQt.QtCore import QObject
@@ -12,11 +11,6 @@ from libqfieldsync.project import ProjectConfiguration, ProjectProperties
 from libqfieldsync.utils.file_utils import is_valid_filepath, isascii
 
 from .offline_converter import ExportType
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    TypedDict = Dict
 
 
 class FeedbackResult:
@@ -49,12 +43,12 @@ class ProjectCheckerFeedback:
     tr = QObject().tr
 
     def __init__(self) -> None:
-        self.feedbacks: Dict[str, List[Feedback]] = {
+        self.feedbacks: dict[str, list[Feedback]] = {
             # if the key is "", it is considered as project feedback
             "": [],
         }
         self.count = 0
-        self.error_feedbacks: List[Feedback] = []
+        self.error_feedbacks: list[Feedback] = []
         self.longest_level_name = len(Feedback.Level.WARNING.value)
 
     def add(self, feedback: Feedback):
@@ -78,7 +72,7 @@ class ProjectChecker:
 
     def __init__(self, project: QgsProject) -> None:
         self.project = project
-        self.project_checks: List[ProjectChecker.CheckConfig] = [
+        self.project_checks: list[ProjectChecker.CheckConfig] = [
             {
                 "level": Feedback.Level.ERROR,
                 "fn": self.check_no_absolute_filepaths,
@@ -110,7 +104,7 @@ class ProjectChecker:
                 "scope": ExportType.Cloud,
             },
         ]
-        self.layer_checks: List[ProjectChecker.CheckConfig] = [
+        self.layer_checks: list[ProjectChecker.CheckConfig] = [
             {
                 "level": Feedback.Level.WARNING,
                 "fn": self.check_layer_has_utf8_datasources,
@@ -296,7 +290,7 @@ class ProjectChecker:
             return None
 
     def check_for_conflicting_base_filenames(self) -> Optional[FeedbackResult]:
-        conflicting_files: List[Path] = []
+        conflicting_files: list[Path] = []
 
         project_file_path = Path(self.project.fileName())
         project_home_path = project_file_path.parent
@@ -528,7 +522,7 @@ class ProjectChecker:
 
     def check_project_layers_sources_actions(self) -> Optional[FeedbackResult]:
         """Check if layers from the same GeoPackage have offline and copy actions."""
-        layer_sources_by_filename: Dict[str, List[LayerSource]] = defaultdict(list)
+        layer_sources_by_filename: dict[str, list[LayerSource]] = defaultdict(list)
 
         for project_layer in self.project.mapLayers().values():
             layer_source = LayerSource(project_layer)

--- a/libqfieldsync/project_checker.py
+++ b/libqfieldsync/project_checker.py
@@ -37,8 +37,12 @@ class Feedback:
     ) -> None:
         self.level = level
         self.message = feedback_result.message
-        self.layer_id = layer.id() if layer else None
-        self.layer_name = layer.name() if layer else None
+        if layer:
+            self.layer_id = layer.id()
+            self.layer_name = layer.name()
+        else:
+            self.layer_id = None
+            self.layer_name = None
 
 
 class ProjectCheckerFeedback:
@@ -248,6 +252,7 @@ class ProjectChecker:
                         'Please change this configuration in "File -> Project settings -> QField" first.'
                     ).format(project_configuration.base_map_theme),
                 )
+
         return None
 
     def check_files_have_unsupported_characters(self) -> Optional[FeedbackResult]:

--- a/libqfieldsync/utils/bad_layer_handler.py
+++ b/libqfieldsync/utils/bad_layer_handler.py
@@ -56,7 +56,7 @@ class set_bad_layer_handler:  # noqa: N801
         # NOTE we should set the bad layer handler only when we need it.
         # Unfortunately we cannot due to a crash when calling `QgsProject.read()` when we already used this context manager.
         # The code below is used as documentation for future generations of engineers willing to fix this.
-        # self.project.setBadLayerHandler(bad_layer_handler)  # noqa: ERA001
+        # self.project.setBadLayerHandler(bad_layer_handler)
 
     def __exit__(self, exc_type, exc_value, traceback):
         # NOTE we should set the bad layer handler only when we need it.
@@ -64,7 +64,7 @@ class set_bad_layer_handler:  # noqa: N801
         # The code below is used as documentation for future generations of engineers willing to fix this.
 
         # global bad_layer_handler
-        # self.project.setBadLayerHandler(None)  # noqa: ERA001
+        # self.project.setBadLayerHandler(None)
         pass
 
     def __call__(self, func):

--- a/libqfieldsync/utils/bad_layer_handler.py
+++ b/libqfieldsync/utils/bad_layer_handler.py
@@ -17,14 +17,15 @@
  ***************************************************************************/
 """
 
-from typing import ClassVar, Dict, Iterable
+from collections.abc import Iterable
+from typing import ClassVar
 
 from qgis.core import QgsProject, QgsProjectBadLayerHandler
 from qgis.PyQt.QtXml import QDomNode
 
 
 class BadLayerHandler(QgsProjectBadLayerHandler):
-    invalid_layer_sources_by_id: ClassVar[Dict[str, str]] = {}
+    invalid_layer_sources_by_id: ClassVar[dict[str, str]] = {}
 
     def handleBadLayers(self, layers: Iterable[QDomNode]):  # noqa: N802
         super().handleBadLayers(layers)

--- a/libqfieldsync/utils/file_utils.py
+++ b/libqfieldsync/utils/file_utils.py
@@ -27,7 +27,7 @@ import shutil
 import subprocess
 import unicodedata
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 from qgis.core import (
     Qgis,
@@ -44,7 +44,7 @@ from qgis.PyQt.QtCore import QCoreApplication
 from .exceptions import NoProjectFoundError, QFieldSyncError
 
 
-def fileparts(filename: str, extension_dot: bool = True) -> Tuple[str, str, str]:
+def fileparts(filename: str, extension_dot: bool = True) -> tuple[str, str, str]:
     path = os.path.dirname(filename)
     basename = os.path.basename(filename)
     name, ext = os.path.splitext(basename)
@@ -57,8 +57,8 @@ def fileparts(filename: str, extension_dot: bool = True) -> Tuple[str, str, str]
 
 
 def get_children_with_extension(
-    parent: str, specified_ext: Union[str, List[str]], count: int = 1
-) -> List[str]:
+    parent: str, specified_ext: Union[str, list[str]], count: int = 1
+) -> list[str]:
     if not os.path.isdir(parent):
         raise QFieldSyncError(
             QCoreApplication.translate(
@@ -355,7 +355,7 @@ def set_relative_embed_layer_symbols_on_project(  # noqa: PLR0912
 
 def get_project_like_files(
     project_filename: Union[str, Path], glob_pattern: str
-) -> List[str]:
+) -> list[str]:
     """
     Get the list of files with names similar to given project name and glob pattern.
 
@@ -384,7 +384,7 @@ def get_project_like_files(
 def copy_additional_project_files(
     source_project_filename: Union[str, Path],
     export_project_filename: Union[str, Path],
-    additional_project_files: List[str],
+    additional_project_files: list[str],
 ):
     source_project_filename = Path(source_project_filename)
     export_project_filename = Path(export_project_filename)

--- a/libqfieldsync/utils/file_utils.py
+++ b/libqfieldsync/utils/file_utils.py
@@ -52,6 +52,7 @@ def fileparts(filename: str, extension_dot: bool = True) -> Tuple[str, str, str]
         ext = "." + ext
     elif not extension_dot and ext.startswith("."):
         ext = ext[1:]
+
     return (path, name, ext)
 
 
@@ -72,10 +73,12 @@ def get_children_with_extension(
     extension_dot = False
     if specified_ext:
         extension_dot = specified_ext[0].startswith(".")
+
     for filename in os.listdir(parent):
         _, _, ext = fileparts(filename, extension_dot=extension_dot)
         if ext in specified_ext:
             res.append(os.path.join(parent, filename))
+
     if len(res) != count:
         raise QFieldSyncError(
             QCoreApplication.translate(

--- a/libqfieldsync/utils/qgis.py
+++ b/libqfieldsync/utils/qgis.py
@@ -21,7 +21,7 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from qgis.core import QgsMapLayer, QgsProject
 
@@ -56,7 +56,7 @@ def make_temp_qgis_file(project: QgsProject) -> str:
     return backup_filename
 
 
-def get_memory_layers(project: QgsProject) -> List[QgsMapLayer]:
+def get_memory_layers(project: QgsProject) -> list[QgsMapLayer]:
     return [
         layer
         for layer in project.mapLayers().values()
@@ -64,6 +64,6 @@ def get_memory_layers(project: QgsProject) -> List[QgsMapLayer]:
     ]
 
 
-def get_qgis_files_within_dir(dirname: Union[str, Path]) -> List[Path]:
+def get_qgis_files_within_dir(dirname: Union[str, Path]) -> list[Path]:
     dirname = Path(dirname)
     return list(dirname.glob("*.qgs")) + list(dirname.glob("*.qgz"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,13 @@ packages = ["libqfieldsync", "libqfieldsync.utils"]
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 
+[tool.flake8]
+exclude = [
+    ".git",
+    "__pycache__",
+]
+select = ["CLB100", "IF100"]
+
 [project]
 name = "libqfieldsync"
 description = "the qfieldsync library"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,21 +60,30 @@ ignore = [
     "S607",
     # https://docs.astral.sh/ruff/rules/try-consider-else/
     "TRY300",
+    # https://docs.astral.sh/ruff/rules/raise-within-try/
+    "TRY301",
     # https://docs.astral.sh/ruff/rules/manual-list-comprehension/
     "PERF401",
     # https://docs.astral.sh/ruff/rules/missing-trailing-comma/
     "COM812",
     # https://docs.astral.sh/ruff/rules/blind-except/
     "BLE001",
-    # https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/
-    # NOTE: The following rule "ISC001" may cause conflicts when used with the formatter.
-    "ISC001",
     # https://docs.astral.sh/ruff/rules/future-rewritable-type-annotation/
     "FA100",
     # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
     "PTH",
     # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
     "ANN",
+    # https://docs.astral.sh/ruff/rules/unnecessary-lambda/
+    # NOTE: ignored because we heavily `qobj.connect.signal(lambda arg: self._method(arg))` in the codebase
+    "PLW0108",
+    # NOTE: ignored because we heavily use `QObject.tr( "" ).format()`
+    "UP032",
+    # NOTE: we should eventually enable no commented out code
+    "ERA001",
+    # https://docs.astral.sh/ruff/rules/missing-todo-link/
+    # NOTE this should be ideally commented out, having a TODO with a task is a must
+    "TD003",
 ]
 
 [tool.ruff.lint.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
-# Support Python 3.7+.
-target-version = "py37"
+# Support Python 3.9+.
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
Similar to what we did in https://github.com/opengisch/qfieldsync/pull/768 :

- Bump Python min version from 3.7 to 3.9
- Actually enforce flake8 checks. 
- Enforce most of the pre-commit checks
- Cleanup code that is no longer used
- Bump pre-commit deps

See individual commits for more info.