### PR TITLE
Fix CI tests to run only on relevant QGIS versions

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,15 +1,14 @@
 ARG QGIS_TEST_VERSION=latest
 FROM  qgis/qgis:${QGIS_TEST_VERSION}
-MAINTAINER Matthias Kuhn <matthias@opengis.ch>
 
 RUN apt-get update \
-    && apt-get install -y \
-         python3-pip \
+    && apt-get install -y python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements.txt /tmp/
-RUN pip3 install -r /tmp/requirements.txt
+
+RUN pip3 install -r /tmp/requirements.txt --break-system-packages
 
 ENV LANG=C.UTF-8
 
-WORKDIR /
+WORKDIR /usr/src

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -42,10 +42,12 @@ jobs:
           retention-days: 7
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
-        qgis_version: [release-3_22, release-3_28, final-3_36_1]
+        # TODO @suricactus: enable QGIS 4 tests
+        qgis_version: ["3.40", "3.44", "ltr"]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
     steps:
@@ -57,6 +59,7 @@ jobs:
       - name: Run tests
         run: |
           docker compose -f .docker/docker-compose.yml run qgis /usr/src/.docker/run-docker-tests.sh
+
   test_packaging:
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
QGIS 4 is disabled for now, but it's out of scope for this PR.