### PR TITLE
Explicitly say that md5 hex is not usedforsecurity

### DIFF
--- a/libqfieldsync/utils/file_utils.py
+++ b/libqfieldsync/utils/file_utils.py
@@ -131,9 +131,7 @@ def import_file_checksum(path: str) -> Optional[str]:
     if os.path.exists(file_path):
         with open(file_path, "rb") as f:
             file_data = f.read()
-            # TODO @suricactus: Python 3.9, pass `usedforsecurity=False`
-            # https://app.clickup.com/t/2192114/QF-6481
-            md5sum = hashlib.md5(file_data).hexdigest()  # noqa: S324
+            md5sum = hashlib.md5(file_data, usedforsecurity=False).hexdigest()
 
     return md5sum
 


### PR DESCRIPTION
We can finally do this, since we bumped the minimal python version to 3.9