### PR TITLE
Add a new `Config` class that sets project level configurations to the qgs file

### DIFF
--- a/libqfieldsync/offline_converter.py
+++ b/libqfieldsync/offline_converter.py
@@ -47,7 +47,7 @@ from qgis.PyQt.QtCore import QCoreApplication, QObject, pyqtSignal
 
 from .layer import LayerSource, SyncAction
 from .offliners import BaseOffliner
-from .project import ProjectConfiguration, ProjectProperties
+from .project import BaseMapType, ProjectConfig
 from .utils.file_utils import (
     copy_additional_project_files,
     copy_attachments,
@@ -149,11 +149,11 @@ class OfflineConverter(QObject):
         self.offliner.progress_mode_set.connect(self._on_offline_editing_max_changed)
         self.offliner.progress_updated.connect(self._on_offline_editing_task_progress)
 
-        self.project_configuration = ProjectConfiguration(project)
+        self._project_config = ProjectConfig(project)
 
         if (
-            self.project_configuration.offline_copy_only_aoi
-            or self.project_configuration.create_base_map
+            self._project_config.offline_copy_only_aoi
+            or self._project_config.create_base_map
         ):
             assert self.area_of_interest.isValid()[0]
             assert self.area_of_interest_crs.isValid(), (
@@ -259,7 +259,7 @@ class OfflineConverter(QObject):
         offline_layers: list[QgsMapLayer] = []
         copied_files = []
 
-        if self.create_basemap and self.project_configuration.create_base_map:
+        if self.create_basemap and self._project_config.create_base_map:
             is_basemap_export_success = self._export_basemap()
 
             if not is_basemap_export_success and not self._is_canceled:
@@ -356,7 +356,7 @@ class OfflineConverter(QObject):
         export_project_filename = self._export_filename
 
         # save the original project path
-        self.project_configuration.original_project_path = str(self.original_filename)
+        self._project_config.original_project_path = str(self.original_filename)
 
         self._check_canceled()
 
@@ -392,7 +392,7 @@ class OfflineConverter(QObject):
 
         if offline_layers:
             bbox = None
-            if self.project_configuration.offline_copy_only_aoi:
+            if self._project_config.offline_copy_only_aoi:
                 bbox = QgsCoordinateTransform(
                     QgsCoordinateReferenceSystem(self.area_of_interest_crs),
                     QgsProject.instance().crs(),
@@ -601,9 +601,9 @@ class OfflineConverter(QObject):
             return False
 
         extent = basemap_extent
-        base_map_type = self.project_configuration.base_map_type
-        if base_map_type == ProjectProperties.BaseMapType.SINGLE_LAYER:
-            if not self.project_configuration.base_map_layer.strip():
+        base_map_type = self._project_config.base_map_type
+        if base_map_type == BaseMapType.SINGLE_LAYER:
+            if not self._project_config.base_map_layer.strip():
                 self.warning.emit(
                     self.tr("Failed to create basemap"),
                     self.tr(
@@ -612,14 +612,14 @@ class OfflineConverter(QObject):
                 )
                 return False
 
-            basemap_layer = project.mapLayer(self.project_configuration.base_map_layer)
+            basemap_layer = project.mapLayer(self._project_config.base_map_layer)
 
             if not basemap_layer:
                 self.warning.emit(
                     self.tr("Failed to create basemap"),
                     self.tr(
                         'Cannot find the configured base layer with id "{}". Please check the project configuration.'
-                    ).format(self.project_configuration.base_map_layer),
+                    ).format(self._project_config.base_map_layer),
                 )
                 return False
 
@@ -629,15 +629,15 @@ class OfflineConverter(QObject):
                 project.crs(),
                 project,
             ).transformBoundingBox(basemap_extent)
-        elif base_map_type == ProjectProperties.BaseMapType.MAP_THEME:
+        elif base_map_type == BaseMapType.MAP_THEME:
             if not project.mapThemeCollection().hasMapTheme(
-                self.project_configuration.base_map_theme
+                self._project_config.base_map_theme
             ):
                 self.warning.emit(
                     self.tr("Failed to create basemap"),
                     self.tr(
                         'Cannot find the configured base theme with name "{}". Please check the project configuration.'
-                    ).format(self.project_configuration.base_map_theme),
+                    ).format(self._project_config.base_map_theme),
                 )
                 return False
 
@@ -646,7 +646,7 @@ class OfflineConverter(QObject):
         return exported_mbtiles
 
     def _export_basemap_as_mbtiles(
-        self, extent: QgsRectangle, base_map_type: ProjectProperties.BaseMapType
+        self, extent: QgsRectangle, base_map_type: BaseMapType
     ) -> bool:
         """
         Exports a basemap to mbtiles format.
@@ -654,7 +654,7 @@ class OfflineConverter(QObject):
 
         Args:
             extent (QgsRectangle): extent of the area of interest
-            base_map_type (ProjectProperties.BaseMapType): basemap type (layer or theme)
+            base_map_type (BaseMapType): basemap type (layer or theme)
 
         Returns:
             bool: if basemap layer could be exported as mbtiles
@@ -670,9 +670,9 @@ class OfflineConverter(QObject):
 
         params = {
             "EXTENT": extent,
-            "ZOOM_MIN": self.project_configuration.base_map_tiles_min_zoom_level,
-            "ZOOM_MAX": self.project_configuration.base_map_tiles_max_zoom_level,
-            "TILE_SIZE": self.project_configuration.base_map_tile_size,
+            "ZOOM_MIN": self._project_config.base_map_tiles_min_zoom_level,
+            "ZOOM_MAX": self._project_config.base_map_tiles_max_zoom_level,
+            "TILE_SIZE": self._project_config.base_map_tile_size,
             "OUTPUT_FILE": str(basemap_export_path),
         }
 
@@ -683,17 +683,17 @@ class OfflineConverter(QObject):
         )
         cloned_project.setCrs(current_project.crs())
 
-        if base_map_type == ProjectProperties.BaseMapType.SINGLE_LAYER:
+        if base_map_type == BaseMapType.SINGLE_LAYER:
             # the `native:tilesxyzmbtiles` alg does not have any LAYERS param
             # so just add basemap layer to the cloned project
             basemap_layer = current_project.mapLayer(
-                self.project_configuration.base_map_layer
+                self._project_config.base_map_layer
             )
             # here we use a cloned version of the raster layer, otherwise QGIS might crash
             clone_layer = basemap_layer.clone()
             cloned_project.addMapLayer(clone_layer)
 
-        elif base_map_type == ProjectProperties.BaseMapType.MAP_THEME:
+        elif base_map_type == BaseMapType.MAP_THEME:
             # clone and recreate the current QGIS project, and recreate original themes
             current_themes = QgsMapThemeCollection(current_project)
             themes_data = {}
@@ -717,7 +717,7 @@ class OfflineConverter(QObject):
             layer_tree_root = cloned_project.layerTreeRoot()
             layer_tree_model = QgsLayerTreeModel(layer_tree_root)
             cloned_project.mapThemeCollection().applyTheme(
-                self.project_configuration.base_map_theme,
+                self._project_config.base_map_theme,
                 layer_tree_root,
                 layer_tree_model,
             )
@@ -746,7 +746,7 @@ class OfflineConverter(QObject):
 
             new_layer = QgsRasterLayer(results["OUTPUT_FILE"], self.tr("Basemap"))
 
-            self.project_configuration.project.addMapLayer(new_layer, False)
+            self._project_config.project.addMapLayer(new_layer, False)
 
             layer_tree = QgsProject.instance().layerTreeRoot()
             layer_tree.insertLayer(len(layer_tree.children()), new_layer)

--- a/libqfieldsync/project.py
+++ b/libqfieldsync/project.py
@@ -1,570 +1,83 @@
-import json
+from enum import Enum
+
+from qgis.core import QgsProject
+
+from libqfieldsync.utils.config_utils import Field, pfield
 
 
-class ProjectProperties:
-    def __init__(self):
-        raise RuntimeError("This object holds only project property static variables")
-
-    BASE_MAP_TYPE = "/baseMapType"
-    CREATE_BASE_MAP = "/createBaseMap"
-    BASE_MAP_THEME = "/baseMapTheme"
-    BASE_MAP_LAYER = "/baseMapLayer"
-    BASE_MAP_TILE_SIZE = "/baseMapTileSize"
-    BASE_MAP_TILES_MIN_ZOOM_LEVEL = "/baseMapTilesMinZoomLevel"
-    BASE_MAP_TILES_MAX_ZOOM_LEVEL = "/baseMapTilesMaxZoomLevel"
-    OFFLINE_COPY_ONLY_AOI = "/offlineCopyOnlyAoi"
-    ORIGINAL_PROJECT_PATH = "/originalProjectPath"
-    IMPORTED_FILES_CHECKSUMS = "/importedFilesChecksums"
-    LAYER_ACTION_PREFERENCE = "/layerActionPreference"
-    AREA_OF_INTEREST = "/areaOfInterest"
-    AREA_OF_INTEREST_CRS = "/areaOfInterestCrs"
-    DIGITIZING_LOGS_LAYER = "/digitizingLogsLayer"
-    INITIAL_ACTIVE_LAYER = "/initialActiveLayer"
-    INITIAL_MAP_MODE = "/initialMapMode"
-    MAXIMUM_IMAGE_WIDTH_HEIGHT = "/maximumImageWidthHeight"
-    FORCE_AUTO_PUSH = "/forceAutoPush"
-    FORCE_AUTO_PUSH_INTERVAL_MINS = "/forceAutoPushIntervalMins"
-    GEOFENCING_IS_ACTIVE = "/geofencingIsActive"
-    GEOFENCING_LAYER = "/geofencingLayer"
-    GEOFENCING_BEHAVIOR = "/geofencingBehavior"
-    GEOFENCING_SHOULD_PREVENT_DIGITIZING = "/geofencingShouldPreventDigitizing"
-    MAP_THEMES_ACTIVE_LAYER = "/mapThemesActiveLayers"
-    FORCE_STAMPING = "/forceStamping"
-    STAMPING_FONT_STYLE = "/stampingFontStyle"
-    STAMPING_HORIZONTAL_ALIGNMENT = "/stampingHorizontalAlignment"
-    STAMPING_IMAGE_DECORATION = "/stampingImageDecoration"
-    STAMPING_DETAILS_TEMPLATE = "/stampingDetailsTemplate"
-    LOCATION_ARROW_FILL_COLOR = "/locationArrowFillColor"
-    LOCATION_ARROW_OUTLINE_COLOR = "/locationArrowOutlineColor"
-    LOCATION_ARROW_SIZE = "/locationArrowSize"
-    COORDINATE_CURSOR_FILL_COLOR = "/coordinateCursorFillColor"
-    COORDINATE_CURSOR_OUTLINE_COLOR = "/coordinateCursorOutlineColor"
-    COORDINATE_CURSOR_SIZE = "/coordinateCursorSize"
-    FEATURE_FORM_WIZARD_MODE_ENABLED = "/featureFormWizardModeEnabled"
-
-    class QFieldItemSize:
-        def __init__(self):
-            raise RuntimeError(
-                "This object holds only project property static variables"
-            )
-
-        TINY = "tiny"
-        NORMAL = "normal"
-        BIG = "big"
-        BIGGEST = "biggest"
-
-    class BaseMapType:
-        def __init__(self):
-            raise RuntimeError(
-                "This object holds only project property static variables"
-            )
-
-        SINGLE_LAYER = "singleLayer"
-        MAP_THEME = "mapTheme"
-
-    class GeofencingBehavior:
-        def __init__(self):
-            raise RuntimeError(
-                "This object holds only project property static variables"
-            )
-
-        ALERT_INSIDE_AREAS = 1
-        ALERT_OUTSIDE_AREAS = 2
-        INFORM_ENTER_LEAVE_AREAS = 3
-
-    class InitialMapMode:
-        def __init__(self):
-            raise RuntimeError(
-                "This object holds only project property static variables"
-            )
-
-        BROWSE = "browse"
-        DIGITIZE = "digitize"
+class QFieldItemSize(str, Enum):
+    TINY = "tiny"
+    NORMAL = "normal"
+    BIG = "big"
+    BIGGEST = "biggest"
 
 
-class ProjectConfiguration:
-    """Manages the QFieldSync specific configuration for a QGIS project."""
+class BaseMapType(str, Enum):
+    SINGLE_LAYER = "singleLayer"
+    MAP_THEME = "mapTheme"
 
-    def __init__(self, project):
+
+class GeofencingBehavior(Enum):
+    ALERT_INSIDE_AREAS = 1
+    ALERT_OUTSIDE_AREAS = 2
+    INFORM_ENTER_LEAVE_AREAS = 3
+
+
+class InitialMapMode(str, Enum):
+    BROWSE = "browse"
+    DIGITIZE = "digitize"
+
+
+class ProjectConfig:
+    def __init__(self, project: QgsProject) -> None:
         self.project = project
-
-    @property
-    def create_base_map(self):
-        create_base_map, _ = self.project.readBoolEntry(
-            "qfieldsync", ProjectProperties.CREATE_BASE_MAP, False
-        )
-        return create_base_map
-
-    @create_base_map.setter
-    def create_base_map(self, value):
-        self.project.writeEntry("qfieldsync", ProjectProperties.CREATE_BASE_MAP, value)
-
-    @property
-    def base_map_type(self):
-        base_map_type, _ = self.project.readEntry(
-            "qfieldsync",
-            ProjectProperties.BASE_MAP_TYPE,
-            ProjectProperties.BaseMapType.SINGLE_LAYER,
-        )
-        if base_map_type != ProjectProperties.BaseMapType.SINGLE_LAYER:
-            return ProjectProperties.BaseMapType.MAP_THEME
-        else:
-            return ProjectProperties.BaseMapType.SINGLE_LAYER
-
-    @base_map_type.setter
-    def base_map_type(self, value):
-        if value not in (
-            ProjectProperties.BaseMapType.SINGLE_LAYER,
-            ProjectProperties.BaseMapType.MAP_THEME,
-        ):
-            raise ValueError("Only supported types can be set")
-
-        self.project.writeEntry("qfieldsync", ProjectProperties.BASE_MAP_TYPE, value)
-
-    @property
-    def base_map_theme(self):
-        base_map_theme, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.BASE_MAP_THEME
-        )
-        return base_map_theme
-
-    @base_map_theme.setter
-    def base_map_theme(self, value):
-        self.project.writeEntry("qfieldsync", ProjectProperties.BASE_MAP_THEME, value)
-
-    @property
-    def base_map_layer(self):
-        base_map_layer, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.BASE_MAP_LAYER
-        )
-        return base_map_layer
-
-    @base_map_layer.setter
-    def base_map_layer(self, value):
-        self.project.writeEntry("qfieldsync", ProjectProperties.BASE_MAP_LAYER, value)
-
-    @property
-    def digitizing_logs_layer(self):
-        digitizing_logs_layer, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.DIGITIZING_LOGS_LAYER
-        )
-        return digitizing_logs_layer
-
-    @digitizing_logs_layer.setter
-    def digitizing_logs_layer(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.DIGITIZING_LOGS_LAYER, value
-        )
-
-    @property
-    def initial_active_layer(self):
-        initial_active_layer, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.INITIAL_ACTIVE_LAYER
-        )
-        return initial_active_layer
-
-    @initial_active_layer.setter
-    def initial_active_layer(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.INITIAL_ACTIVE_LAYER, value
-        )
-
-    @property
-    def initial_map_mode(self):
-        initial_map_mode, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.INITIAL_MAP_MODE
-        )
-        if initial_map_mode in (
-            ProjectProperties.InitialMapMode.BROWSE,
-            ProjectProperties.InitialMapMode.DIGITIZE,
-        ):
-            return initial_map_mode
-
-        return ProjectProperties.InitialMapMode.BROWSE
-
-    @initial_map_mode.setter
-    def initial_map_mode(self, value):
-        self.project.writeEntry("qfieldsync", ProjectProperties.INITIAL_MAP_MODE, value)
-
-    @property
-    def geofencing_layer(self):
-        geofencing_layer, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.GEOFENCING_LAYER
-        )
-        return geofencing_layer
-
-    @geofencing_layer.setter
-    def geofencing_layer(self, value):
-        self.project.writeEntry("qfieldsync", ProjectProperties.GEOFENCING_LAYER, value)
-
-    @property
-    def geofencing_behavior(self):
-        geofencing_behavior, _ = self.project.readNumEntry(
-            "qfieldsync",
-            ProjectProperties.GEOFENCING_BEHAVIOR,
-            ProjectProperties.GeofencingBehavior.ALERT_INSIDE_AREAS,
-        )
-        return geofencing_behavior
-
-    @geofencing_behavior.setter
-    def geofencing_behavior(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.GEOFENCING_BEHAVIOR, value
-        )
-
-    @property
-    def geofencing_should_prevent_digitizing(self):
-        geofencing_should_prevent_digitizing, _ = self.project.readBoolEntry(
-            "qfieldsync", ProjectProperties.GEOFENCING_SHOULD_PREVENT_DIGITIZING, False
-        )
-        return geofencing_should_prevent_digitizing
-
-    @geofencing_should_prevent_digitizing.setter
-    def geofencing_should_prevent_digitizing(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.GEOFENCING_SHOULD_PREVENT_DIGITIZING, value
-        )
-
-    @property
-    def stamping_font_style(self):
-        stamping_font_style, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.STAMPING_FONT_STYLE
-        )
-        return stamping_font_style
-
-    @stamping_font_style.setter
-    def stamping_font_style(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.STAMPING_FONT_STYLE, value
-        )
-
-    @property
-    def stamping_horizontal_alignment(self):
-        stamping_horizontal_alignment, _ = self.project.readNumEntry(
-            "qfieldsync", ProjectProperties.STAMPING_HORIZONTAL_ALIGNMENT
-        )
-        return stamping_horizontal_alignment
-
-    @stamping_horizontal_alignment.setter
-    def stamping_horizontal_alignment(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.STAMPING_HORIZONTAL_ALIGNMENT, value
-        )
-
-    @property
-    def stamping_image_decoration(self):
-        stamping_image_decoration, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.STAMPING_IMAGE_DECORATION
-        )
-        return stamping_image_decoration
-
-    @stamping_image_decoration.setter
-    def stamping_image_decoration(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.STAMPING_IMAGE_DECORATION, value
-        )
-
-    @property
-    def stamping_details_template(self):
-        stamping_details_template, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.STAMPING_DETAILS_TEMPLATE
-        )
-        return stamping_details_template
-
-    @stamping_details_template.setter
-    def stamping_details_template(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.STAMPING_DETAILS_TEMPLATE, value
-        )
-
-    @property
-    def force_stamping(self):
-        force_stamping, _ = self.project.readBoolEntry(
-            "qfieldsync", ProjectProperties.FORCE_STAMPING, False
-        )
-        return force_stamping
-
-    @force_stamping.setter
-    def force_stamping(self, value):
-        self.project.writeEntry("qfieldsync", ProjectProperties.FORCE_STAMPING, value)
-
-    @property
-    def feature_form_wizard_mode_enabled(self):
-        feature_form_wizard_mode_enabled, _ = self.project.readBoolEntry(
-            "qfieldsync", ProjectProperties.FEATURE_FORM_WIZARD_MODE_ENABLED, False
-        )
-        return feature_form_wizard_mode_enabled
-
-    @feature_form_wizard_mode_enabled.setter
-    def feature_form_wizard_mode_enabled(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.FEATURE_FORM_WIZARD_MODE_ENABLED, value
-        )
-
-    @property
-    def map_themes_active_layer(self):
-        entries_json, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.MAP_THEMES_ACTIVE_LAYER
-        )
-
-        try:
-            entries = json.loads(entries_json)
-        except Exception:
-            entries = {}
-
-        return entries
-
-    @map_themes_active_layer.setter
-    def map_themes_active_layer(self, value):
-        self.project.writeEntry(
-            "qfieldsync",
-            ProjectProperties.MAP_THEMES_ACTIVE_LAYER,
-            json.dumps(value),
-        )
-
-    @property
-    def geofencing_is_active(self):
-        geofencing_is_active, _ = self.project.readBoolEntry(
-            "qfieldsync", ProjectProperties.GEOFENCING_IS_ACTIVE, False
-        )
-        return geofencing_is_active
-
-    @geofencing_is_active.setter
-    def geofencing_is_active(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.GEOFENCING_IS_ACTIVE, value
-        )
-
-    @property
-    def maximum_image_width_height(self):
-        maximum_image_width_height, _ = self.project.readNumEntry(
-            "qfieldsync", ProjectProperties.MAXIMUM_IMAGE_WIDTH_HEIGHT, 0
-        )
-        return maximum_image_width_height
-
-    @maximum_image_width_height.setter
-    def maximum_image_width_height(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.MAXIMUM_IMAGE_WIDTH_HEIGHT, value
-        )
-
-    @property
-    def force_auto_push(self):
-        force_auto_push, _ = self.project.readBoolEntry(
-            "qfieldsync", ProjectProperties.FORCE_AUTO_PUSH, False
-        )
-        return force_auto_push
-
-    @force_auto_push.setter
-    def force_auto_push(self, value):
-        self.project.writeEntry("qfieldsync", ProjectProperties.FORCE_AUTO_PUSH, value)
-
-    @property
-    def force_auto_push_interval_mins(self):
-        force_auto_push_interval_mins, _ = self.project.readNumEntry(
-            "qfieldsync", ProjectProperties.FORCE_AUTO_PUSH_INTERVAL_MINS, 30
-        )
-        return force_auto_push_interval_mins
-
-    @force_auto_push_interval_mins.setter
-    def force_auto_push_interval_mins(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.FORCE_AUTO_PUSH_INTERVAL_MINS, value
-        )
-
-    @property
-    def base_map_tile_size(self):
-        base_map_tile_size, _ = self.project.readNumEntry(
-            "qfieldsync", ProjectProperties.BASE_MAP_TILE_SIZE, 1024
-        )
-        return base_map_tile_size
-
-    @base_map_tile_size.setter
-    def base_map_tile_size(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.BASE_MAP_TILE_SIZE, value
-        )
-
-    @property
-    def base_map_tiles_min_zoom_level(self) -> int:
-        base_map_tiles_min_zoom_level, _ = self.project.readNumEntry(
-            "qfieldsync", ProjectProperties.BASE_MAP_TILES_MIN_ZOOM_LEVEL, 14
-        )
-        return base_map_tiles_min_zoom_level
-
-    @base_map_tiles_min_zoom_level.setter
-    def base_map_tiles_min_zoom_level(self, value: int):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.BASE_MAP_TILES_MIN_ZOOM_LEVEL, value
-        )
-
-    @property
-    def base_map_tiles_max_zoom_level(self) -> int:
-        base_map_tiles_max_zoom_level, _ = self.project.readNumEntry(
-            "qfieldsync", ProjectProperties.BASE_MAP_TILES_MAX_ZOOM_LEVEL, 14
-        )
-        return base_map_tiles_max_zoom_level
-
-    @base_map_tiles_max_zoom_level.setter
-    def base_map_tiles_max_zoom_level(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.BASE_MAP_TILES_MAX_ZOOM_LEVEL, value
-        )
-
-    @property
-    def offline_copy_only_aoi(self):
-        offline_copy_only_aoi, _ = self.project.readBoolEntry(
-            "qfieldsync", ProjectProperties.OFFLINE_COPY_ONLY_AOI
-        )
-        return offline_copy_only_aoi
-
-    @offline_copy_only_aoi.setter
-    def offline_copy_only_aoi(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.OFFLINE_COPY_ONLY_AOI, value
-        )
-
-    @property
-    def original_project_path(self):
-        original_project_path, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.ORIGINAL_PROJECT_PATH
-        )
-        return original_project_path
-
-    @original_project_path.setter
-    def original_project_path(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.ORIGINAL_PROJECT_PATH, value
-        )
-
-    @property
-    def imported_files_checksums(self):
-        imported_files_checksums, _ = self.project.readListEntry(
-            "qfieldsync", ProjectProperties.IMPORTED_FILES_CHECKSUMS
-        )
-        return imported_files_checksums
-
-    @imported_files_checksums.setter
-    def imported_files_checksums(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.IMPORTED_FILES_CHECKSUMS, value
-        )
-
-    @property
-    def layer_action_preference(self):
-        layer_action_preference, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.LAYER_ACTION_PREFERENCE
-        )
-        return layer_action_preference
-
-    @layer_action_preference.setter
-    def layer_action_preference(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.LAYER_ACTION_PREFERENCE, value
-        )
-
-    @property
-    def area_of_interest(self):
-        area_of_interest, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.AREA_OF_INTEREST
-        )
-        return area_of_interest
-
-    @area_of_interest.setter
-    def area_of_interest(self, value):
-        self.project.writeEntry("qfieldsync", ProjectProperties.AREA_OF_INTEREST, value)
-
-    @property
-    def area_of_interest_crs(self):
-        area_of_interest_crs, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.AREA_OF_INTEREST_CRS
-        )
-        return area_of_interest_crs
-
-    @area_of_interest_crs.setter
-    def area_of_interest_crs(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.AREA_OF_INTEREST_CRS, value
-        )
-
-    @property
-    def location_arrow_fill_color(self):
-        color, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.LOCATION_ARROW_FILL_COLOR, ""
-        )
-        return color
-
-    @location_arrow_fill_color.setter
-    def location_arrow_fill_color(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.LOCATION_ARROW_FILL_COLOR, value
-        )
-
-    @property
-    def location_arrow_outline_color(self):
-        color, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.LOCATION_ARROW_OUTLINE_COLOR, ""
-        )
-        return color
-
-    @location_arrow_outline_color.setter
-    def location_arrow_outline_color(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.LOCATION_ARROW_OUTLINE_COLOR, value
-        )
-
-    @property
-    def location_arrow_size(self):
-        size, _ = self.project.readEntry(
-            "qfieldsync",
-            ProjectProperties.LOCATION_ARROW_SIZE,
-            ProjectProperties.QFieldItemSize.NORMAL,
-        )
-        return size
-
-    @location_arrow_size.setter
-    def location_arrow_size(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.LOCATION_ARROW_SIZE, value
-        )
-
-    @property
-    def coordinate_cursor_fill_color(self):
-        color, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.COORDINATE_CURSOR_FILL_COLOR, ""
-        )
-        return color
-
-    @coordinate_cursor_fill_color.setter
-    def coordinate_cursor_fill_color(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.COORDINATE_CURSOR_FILL_COLOR, value
-        )
-
-    @property
-    def coordinate_cursor_outline_color(self):
-        color, _ = self.project.readEntry(
-            "qfieldsync", ProjectProperties.COORDINATE_CURSOR_OUTLINE_COLOR, ""
-        )
-        return color
-
-    @coordinate_cursor_outline_color.setter
-    def coordinate_cursor_outline_color(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.COORDINATE_CURSOR_OUTLINE_COLOR, value
-        )
-
-    @property
-    def coordinate_cursor_size(self):
-        size, _ = self.project.readEntry(
-            "qfieldsync",
-            ProjectProperties.COORDINATE_CURSOR_SIZE,
-            ProjectProperties.QFieldItemSize.NORMAL,
-        )
-        return size
-
-    @coordinate_cursor_size.setter
-    def coordinate_cursor_size(self, value):
-        self.project.writeEntry(
-            "qfieldsync", ProjectProperties.COORDINATE_CURSOR_SIZE, value
-        )
+        self.prefix = "qfieldsync"
+
+    create_base_map = pfield(bool, "/createBaseMap", False)
+    base_map_type = pfield(BaseMapType, "/baseMapType", BaseMapType.SINGLE_LAYER)
+    base_map_theme = pfield(str, "/baseMapTheme")
+    base_map_layer = pfield(str, "/baseMapLayer")
+    digitizing_logs_layer = pfield(str, "/digitizingLogsLayer")
+    initial_active_layer = pfield(str, "/initialActiveLayer")
+    initial_map_mode = pfield(InitialMapMode, "/initialMapMode", InitialMapMode.BROWSE)
+    geofencing_layer = pfield(str, "/geofencingLayer")
+    geofencing_behavior = pfield(
+        GeofencingBehavior, "/geofencingBehavior", GeofencingBehavior.ALERT_INSIDE_AREAS
+    )
+    geofencing_should_prevent_digitizing = pfield(
+        bool, "/geofencingShouldPreventDigitizing", False
+    )
+    stamping_font_style = pfield(str, "/stampingFontStyle")
+    stamping_horizontal_alignment = pfield(int, "/stampingHorizontalAlignment")
+    stamping_image_decoration = pfield(str, "/stampingImageDecoration")
+    stamping_details_template = pfield(str, "/stampingDetailsTemplate")
+    force_stamping = pfield(bool, "/forceStamping", False)
+    map_themes_active_layer = pfield(dict, "/mapThemesActiveLayers", dict)
+    geofencing_is_active = pfield(bool, "/geofencingIsActive", False)
+    maximum_image_width_height = pfield(int, "/maximumImageWidthHeight", 0)
+    force_auto_push = pfield(bool, "/forceAutoPush", False)
+    force_auto_push_interval_mins = pfield(int, "/forceAutoPushIntervalMins", 30)
+    base_map_tile_size = pfield(int, "/baseMapTileSize", 1024)
+    base_map_tiles_min_zoom_level = pfield(int, "/baseMapTilesMinZoomLevel", 14)
+    base_map_tiles_max_zoom_level = pfield(int, "/baseMapTilesMaxZoomLevel", 14)
+    offline_copy_only_aoi = pfield(bool, "/offlineCopyOnlyAoi", False)
+    original_project_path = pfield(str, "/originalProjectPath", "")
+    imported_files_checksums: Field["list[str]"] = pfield(
+        list, "/importedFilesChecksums", list
+    )
+    layer_action_preference = pfield(str, "/layerActionPreference")
+    area_of_interest = pfield(str, "/areaOfInterest")
+    area_of_interest_crs = pfield(str, "/areaOfInterestCrs")
+    feature_form_wizard_mode_enabled = pfield(
+        bool, "/featureFormWizardModeEnabled", False
+    )
+    location_arrow_fill_color = pfield(str, "/locationArrowFillColor")
+    location_arrow_outline_color = pfield(str, "/locationArrowOutlineColor")
+    location_arrow_size = pfield(
+        QFieldItemSize, "/locationArrowSize", QFieldItemSize.NORMAL
+    )
+    coordinate_cursor_fill_color = pfield(str, "/coordinateCursorFillColor")
+    coordinate_cursor_outline_color = pfield(str, "/coordinateCursorOutlineColor")
+    coordinate_cursor_size = pfield(
+        QFieldItemSize, "/coordinateCursorSize", QFieldItemSize.NORMAL
+    )

--- a/libqfieldsync/project_checker.py
+++ b/libqfieldsync/project_checker.py
@@ -7,7 +7,7 @@ from qgis.core import Qgis, QgsMapLayer, QgsProject
 from qgis.PyQt.QtCore import QObject
 
 from libqfieldsync.layer import LayerSource, SyncAction, UnsupportedPrimaryKeyError
-from libqfieldsync.project import ProjectConfiguration, ProjectProperties
+from libqfieldsync.project import BaseMapType, ProjectConfig
 from libqfieldsync.utils.file_utils import is_valid_filepath, isascii
 
 from .offline_converter import ExportType
@@ -216,17 +216,17 @@ class ProjectChecker:
             return None
 
     def check_basemap_configuration(self) -> Optional[FeedbackResult]:
-        project_configuration = ProjectConfiguration(self.project)
+        project_config = ProjectConfig(self.project)
 
-        if not project_configuration.create_base_map:
+        if not project_config.create_base_map:
             return None
 
-        base_map_type = project_configuration.base_map_type
+        base_map_type = project_config.base_map_type
 
-        if base_map_type == ProjectProperties.BaseMapType.SINGLE_LAYER:
-            basemap_layer = self.project.mapLayer(project_configuration.base_map_layer)
+        if base_map_type == BaseMapType.SINGLE_LAYER:
+            basemap_layer = self.project.mapLayer(project_config.base_map_layer)
 
-            if not project_configuration.base_map_layer.strip():
+            if not project_config.base_map_layer.strip():
                 return FeedbackResult(
                     self.tr(
                         "No basemap layer selected. "
@@ -238,18 +238,18 @@ class ProjectChecker:
                     self.tr(
                         'Cannot find the configured base layer with id "{}". '
                         'Please change this configuration in "Project -> Properties... -> QField" first.'
-                    ).format(project_configuration.base_map_layer),
+                    ).format(project_config.base_map_layer),
                 )
 
-        elif base_map_type == ProjectProperties.BaseMapType.MAP_THEME:
+        elif base_map_type == BaseMapType.MAP_THEME:
             if not self.project.mapThemeCollection().hasMapTheme(
-                project_configuration.base_map_theme
+                project_config.base_map_theme
             ):
                 return FeedbackResult(
                     self.tr(
                         'Cannot find the configured base theme with name "{}".'
                         'Please change this configuration in "Project -> Properties... -> QField" first.'
-                    ).format(project_configuration.base_map_theme),
+                    ).format(project_config.base_map_theme),
                 )
 
         return None

--- a/libqfieldsync/utils/config_utils.py
+++ b/libqfieldsync/utils/config_utils.py
@@ -1,0 +1,205 @@
+import json
+from collections.abc import Callable
+from copy import deepcopy
+from enum import Enum
+from typing import (
+    Any,
+    Generic,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
+
+from qgis.core import QgsProject
+
+T = TypeVar("T")
+
+
+class ObjectInterface(Protocol):
+    prefix: str
+    project: QgsProject
+
+
+class Field(Generic[T]):
+    def __init__(self, value_type: type[T], name: str, default: Any = None) -> None:
+        self.value_type = value_type
+        self.entry_name = name
+        self.default = default
+
+        if self.default is None:
+            if self.value_type is list:
+                self.default = []
+        else:
+            if callable(self.default):
+                default_value = self.default()
+            else:
+                default_value = self.default
+
+            assert isinstance(default_value, self.value_type)
+
+    @overload
+    def __get__(self, obj: None, owner: Any = None) -> "Field[T]": ...
+
+    @overload
+    def __get__(self, obj: "ObjectInterface", owner: Any = None) -> T: ...
+
+    def __get__(  # noqa: PLR0912
+        self, obj: Optional["ObjectInterface"], owner: Any = None
+    ) -> Union["Field[T]", T]:
+        if obj is None:
+            return self
+
+        default: Any
+        if self.value_type is bool:
+            default = self._get_default()
+
+            value, _ = obj.project.readBoolEntry(obj.prefix, self.entry_name, default)
+        elif self.value_type is float:
+            default = self._get_default()
+
+            value, _ = obj.project.readDoubleEntry(obj.prefix, self.entry_name, default)
+        elif self.value_type is int:
+            default = self._get_default()
+
+            if default is None:
+                value, _ = obj.project.readNumEntry(obj.prefix, self.entry_name)
+            else:
+                value, _ = obj.project.readNumEntry(
+                    obj.prefix, self.entry_name, default
+                )
+        elif self.value_type is str:
+            default = self._get_default()
+
+            value, _ = obj.project.readEntry(obj.prefix, self.entry_name, default or "")
+        elif issubclass(self.value_type, Enum):
+            default = self._get_default()
+
+            if default is None:
+                default_value = None
+            else:
+                default_value = default.value
+
+            if issubclass(self.value_type, str):
+                value, _ = obj.project.readEntry(
+                    obj.prefix, self.entry_name, default_value
+                )
+            else:
+                default_value = cast("int", default_value)
+
+                value, _ = obj.project.readNumEntry(
+                    obj.prefix, self.entry_name, default_value
+                )
+
+            value = self.value_type(value)
+        elif self.value_type is list:
+            default = self._get_default()
+
+            value, _ = obj.project.readListEntry(obj.prefix, self.entry_name, default)
+        else:
+            default = self._get_default()
+
+            if default is None:
+                default_entry_value = None
+            else:
+                default_entry_value = json.dumps(default)
+
+            encoded_value, _ = obj.project.readEntry(
+                obj.prefix, self.entry_name, default_entry_value
+            )
+
+            if encoded_value is None or encoded_value == "":
+                value = default
+            else:
+                value = json.loads(encoded_value)
+
+        return cast("T", value)
+
+    def __set__(self, obj: "ObjectInterface", value: T) -> None:  # noqa: PLR0912
+        if value is None:
+            obj.project.writeEntry(obj.prefix, self.entry_name, value)
+            return
+
+        if self.value_type is bool:
+            if not isinstance(value, bool):
+                raise TypeError(
+                    f"Value for {self.entry_name} must be of type {self.value_type}, but got {type(value)}!"
+                )
+
+            obj.project.writeEntryBool(obj.prefix, self.entry_name, value)
+        elif self.value_type is int:
+            if not isinstance(value, int):
+                raise TypeError(
+                    f"Value for {self.entry_name} must be of type {self.value_type}, but got {type(value)}!"
+                )
+
+            obj.project.writeEntry(obj.prefix, self.entry_name, value)
+        elif self.value_type is float:
+            if not isinstance(value, float):
+                raise TypeError(
+                    f"Value for {self.entry_name} must be of type {self.value_type}, but got {type(value)}!"
+                )
+
+            obj.project.writeEntryDouble(obj.prefix, self.entry_name, value)
+        elif self.value_type is str:
+            if not isinstance(value, str):
+                raise TypeError(
+                    f"Value for {self.entry_name} must be of type {self.value_type}, but got {type(value)}!"
+                )
+
+            obj.project.writeEntry(obj.prefix, self.entry_name, value)
+        elif issubclass(self.value_type, Enum):
+            if not isinstance(value, self.value_type):
+                raise TypeError(
+                    f"Value for {self.entry_name} must be of type {self.value_type}, but got {type(value)}!"
+                )
+
+            obj.project.writeEntry(obj.prefix, self.entry_name, value.value)
+        elif self.value_type is list:
+            if not isinstance(value, list):
+                raise TypeError(
+                    f"Value for {self.entry_name} must be of type {self.value_type}, but got {type(value)}!"
+                )
+
+            obj.project.writeEntry(obj.prefix, self.entry_name, value)
+        else:
+            entry_value: Optional[str]
+
+            if value is None:
+                entry_value = value
+            else:
+                entry_value = json.dumps(value)
+
+            obj.project.writeEntry(obj.prefix, self.entry_name, entry_value)
+
+    def _get_default(self) -> Optional[T]:
+        if callable(self.default):
+            default = self.default()
+        else:
+            default = deepcopy(self.default)
+
+        if default is None:
+            return None
+
+        assert isinstance(default, self.value_type)
+
+        return cast("T", default)
+
+
+@overload
+def pfield(value_type: type[T], name: str) -> Field[Optional[T]]: ...
+
+
+@overload
+def pfield(value_type: type[T], name: str, default: Callable[[], T]) -> Field[T]: ...
+
+
+@overload
+def pfield(value_type: type[T], name: str, default: T) -> Field[T]: ...
+
+
+def pfield(value_type: Any, name: str, default: Any = None) -> Field[Any]:
+    """Convenience function for defining project fields with less boilerplate."""
+    return Field(value_type, name, default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,10 @@ max-complexity = 30
 # E501 reports lines that exceed the length of 120.
 max-line-length = 120
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["D", "ANN", "PLR", "SLF", "ARG001", "PGH003", "INP001"]
+"__init__.py" = ["F401"]
+
 [tool.setuptools]
 packages = ["libqfieldsync", "libqfieldsync.utils"]
 

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -1,0 +1,262 @@
+from enum import Enum
+
+import pytest
+from qgis.core import QgsProject
+from qgis.testing import start_app
+
+from libqfieldsync.utils.config_utils import Field, pfield
+
+start_app()
+
+
+class StringEnum(str, Enum):
+    FOO = "foo"
+    BAR = "bar"
+
+
+class NumericEnum(Enum):
+    ONE = 1
+    TWO = 2
+
+
+class StringifiedValue:
+    def __str__(self) -> str:
+        return "serialized-value"
+
+
+class ConfigUnderTest:
+    def __init__(self, project: QgsProject) -> None:
+        self.project = project
+        self.prefix = "qfieldsync"
+
+    bool_value = pfield(bool, "bool_value", False)
+    float_value = pfield(float, "float_value", 1.5)
+    int_value = pfield(int, "int_value", 3)
+    list_value = pfield(list, "list_value")
+    text_value = pfield(str, "text_value")
+    text_with_default = pfield(str, "text_with_default", "fallback")
+    string_enum_value = pfield(StringEnum, "string_enum_value", StringEnum.FOO)
+    numeric_enum_value = pfield(NumericEnum, "numeric_enum_value", NumericEnum.ONE)
+    passthrough_value = pfield(str, "passthrough_value", "unused")
+
+
+@pytest.fixture
+def project():
+    project = QgsProject()
+    project.clear()
+    yield project
+    project.clear()
+
+
+@pytest.fixture
+def config(project):
+    return ConfigUnderTest(project)
+
+
+@pytest.mark.parametrize(
+    ("value_type", "default"),
+    [
+        (bool, "nope"),
+        (float, 1),
+        (int, 1.5),
+        (list, "not-a-list"),
+        (str, 12),
+        (StringEnum, "foo"),
+        (NumericEnum, "what"),
+    ],
+)
+def test_field_rejects_invalid_defaults(value_type, default):
+    with pytest.raises(AssertionError):
+        Field(value_type, "invalid", default)
+
+
+def test_list_field_without_default_gets_empty_list_default():
+    list_field = Field(list, "items")
+
+    assert list_field.default == []
+
+
+def test_descriptor_access_on_class_returns_field():
+    assert isinstance(ConfigUnderTest.bool_value, Field)
+
+
+def test_bool_field_reads_from_qgs_project(project, config):
+    project.writeEntryBool("qfieldsync", "bool_value", True)
+
+    assert config.bool_value is True
+
+
+def test_float_field_reads_from_qgs_project(project, config):
+    project.writeEntryDouble("qfieldsync", "float_value", 2.5)
+
+    assert config.float_value == 2.5
+
+
+def test_int_field_reads_from_qgs_project(project, config):
+    project.writeEntry("qfieldsync", "int_value", 8)
+
+    assert config.int_value == 8
+
+
+def test_list_field_reads_from_qgs_project(project, config):
+    project.writeEntry("qfieldsync", "list_value", ["a", "b"])
+
+    assert config.list_value == ["a", "b"]
+
+
+def test_string_enum_field_reads_and_casts_to_enum(project, config):
+    project.writeEntry("qfieldsync", "string_enum_value", "bar")
+
+    assert config.string_enum_value is StringEnum.BAR
+
+
+def test_numeric_enum_field_reads_and_casts_to_enum(project, config):
+    project.writeEntry("qfieldsync", "numeric_enum_value", 2)
+
+    assert config.numeric_enum_value is NumericEnum.TWO
+
+
+def test_text_field_reads_plain_string(project, config):
+    project.writeEntry("qfieldsync", "text_value", "hello")
+
+    assert config.text_value == "hello"
+
+
+def test_text_field_returns_default_when_entry_is_missing(config):
+    assert config.text_with_default == "fallback"
+
+
+def test_text_field_returns_empty_string_when_no_default_and_entry_is_missing(config):
+    assert config.text_value == ""
+
+
+def test_bool_field_writes_with_bool_writer(project, config):
+    config.bool_value = True
+
+    assert project.readBoolEntry("qfieldsync", "bool_value", False) == (True, True)
+    assert config.bool_value is True
+
+
+def test_float_field_writes_with_double_writer(project, config):
+    config.float_value = 4.5
+
+    assert project.readDoubleEntry("qfieldsync", "float_value", 0.0) == (4.5, True)
+    assert config.float_value == 4.5
+
+
+def test_int_field_writes_with_entry_writer(project, config):
+    config.int_value = 10
+
+    assert project.readNumEntry("qfieldsync", "int_value", 0) == (10, True)
+    assert config.int_value == 10
+
+
+def test_enum_field_writes_enum_values(project, config):
+    config.string_enum_value = StringEnum.BAR
+    config.numeric_enum_value = NumericEnum.TWO
+
+    assert project.readEntry("qfieldsync", "string_enum_value", "") == ("bar", True)
+    assert project.readNumEntry("qfieldsync", "numeric_enum_value", 0) == (2, True)
+    assert config.string_enum_value is StringEnum.BAR
+    assert config.numeric_enum_value is NumericEnum.TWO
+
+
+def test_text_value_writes_through_entry_writer(project, config):
+    config.text_value = "plain-text"
+
+    assert project.readEntry("qfieldsync", "text_value", "fallback") == (
+        "plain-text",
+        True,
+    )
+    assert config.text_value == "plain-text"
+
+
+def test_list_value_writes_through_list_storage(project, config):
+    config.list_value = ["a", "b"]
+
+    assert project.readListEntry("qfieldsync", "list_value", []) == (["a", "b"], True)
+    assert config.list_value == ["a", "b"]
+
+
+def test_bool_field_rejects_non_bool_value(config):
+    with pytest.raises(TypeError):
+        config.bool_value = "not-a-bool"
+
+
+def test_numeric_enum_field_returns_default_when_entry_is_missing(config):
+    assert config.numeric_enum_value is NumericEnum.ONE
+
+
+def test_list_field_returns_empty_list_when_entry_is_missing(config):
+    assert config.list_value == []
+
+
+def test_none_value_is_stored_as_empty_string(project, config):
+    config.passthrough_value = None
+
+    assert project.readEntry("qfieldsync", "passthrough_value", "fallback") == (
+        "",
+        True,
+    )
+    assert config.passthrough_value == ""
+
+
+def test_non_primitive_value_is_stringified_before_writing(project, config):
+    config.passthrough_value = str(StringifiedValue())
+
+    assert project.readEntry("qfieldsync", "passthrough_value", "fallback") == (
+        "serialized-value",
+        True,
+    )
+    assert config.passthrough_value == "serialized-value"
+
+
+def test_dict_value_is_json_encoded(project):
+    def default_dict():
+        return {"key1": 1}
+
+    class JsonEncodedConfig:
+        def __init__(self, project: QgsProject) -> None:
+            self.project = project
+            self.prefix = "qfieldsync"
+
+        without_default = pfield(dict, "without_default")
+        with_default = pfield(dict, "with_default", default_dict)
+
+    c = JsonEncodedConfig(project)
+
+    assert c.without_default is None
+
+    c.without_default = {"a": 1}
+
+    assert c.without_default == {"a": 1}
+    # Check that the raw stored value is JSON-encoded, not just stringified as a dict
+    assert project.readEntry("qfieldsync", "without_default", "") == (
+        '{"a": 1}',
+        True,
+    )
+
+    assert c.with_default == default_dict()
+
+    c.with_default = {"b": 2}
+
+    assert c.with_default == {"b": 2}
+    # Check that the raw stored value is JSON-encoded, not just stringified as a dict
+    assert project.readEntry("qfieldsync", "with_default", "") == (
+        '{"b": 2}',
+        True,
+    )
+
+
+def test_mutable_default_value_is_deep_copied(project):
+    default_value = {"nested": {"items": []}}
+    expected_value = {"nested": {"items": []}}
+
+    field = Field(dict, "mutable_default", default_value)
+
+    first_value = field._get_default()
+    assert first_value is not None
+    first_value["nested"]["items"].append("changed")
+
+    assert field._get_default() != first_value
+    assert field._get_default() == expected_value


### PR DESCRIPTION
Previously one was required to use `ProjectProperties` and to explicitly define a getter and setter for a given property. This was tiresome, repetitive
 and error prone.

Defining settings now is much more simplistic:

```
class Config:
    def __init__(self, project: QgsProject) -> None:
        self.project = project

    create_base_map = pfield(bool, "/createBaseMap", False)
```

Where `pfield` is a function that takes:
1) data type of the project property
2) path of the property after the prefix (prefix is `QFieldSync`) 3) default value of the property if any

The rest of the "magic" is within the `Field` type.

This is very similar to what `settings_manager` does and it will eventually replace it.