### PR TITLE
Avoid fatal errors when unable to offline a feature geometry or failing to commit changes into the offlined layer

### DIFF
--- a/libqfieldsync/offliners.py
+++ b/libqfieldsync/offliners.py
@@ -21,7 +21,6 @@ from qgis.core import (
     QgsProject,
     QgsRectangle,
     QgsVectorLayer,
-    edit,
 )
 from qgis.PyQt.QtCore import QFileInfo, QMetaType, QObject, pyqtSignal
 
@@ -328,25 +327,48 @@ class PythonMiniOffliner(BaseOffliner):
                 f"We were not able to create the layer {layer.name()} ..."
             )
 
-        with edit(new_layer):
-            new_fields = new_layer.fields()
+        if not new_layer.startEditing():
+            raise RuntimeError(
+                f"Cannot write into the offline Geopackage for {layer.name()}"
+            )
 
-            for feature in layer.dataProvider().getFeatures(feature_request):
-                # Prepend an empty attribute for the new FID
-                attrs = [None, *feature.attributes()]
+        new_fields = new_layer.fields()
 
-                # Fixup list and json attributes
-                for i in range(new_layer.fields().count()):
-                    field_type = new_layer.fields().at(i).type()
-                    if field_type in (
-                        QMetaType.Type.QStringList,
-                        QMetaType.Type.QVariantList,
-                    ):
-                        attrs[i] = QgsJsonUtils.encodeValue(attrs[i])
+        for feature in layer.dataProvider().getFeatures(feature_request):
+            # Prepend an empty attribute for the new FID
+            attrs = [None, *feature.attributes()]
 
-                feature.setFields(new_fields)
-                feature.setAttributes(attrs)
-                new_layer.addFeature(feature)
+            # Fixup list and json attributes
+            for i in range(new_layer.fields().count()):
+                field_type = new_layer.fields().at(i).type()
+                if field_type in (
+                    QMetaType.Type.QStringList,
+                    QMetaType.Type.QVariantList,
+                ):
+                    attrs[i] = QgsJsonUtils.encodeValue(attrs[i])
+
+            feature.setFields(new_fields)
+            feature.setAttributes(attrs)
+
+            if not feature.geometry().isNull():
+                geometry = new_layer.dataProvider().convertToProviderType(
+                    feature.geometry()
+                )
+                if geometry.isNull():
+                    # Skip feature containing a geometry that is incompatible with Geopackage
+                    logger.warning(
+                        f"Skipping feature ID {feature.id()} when offlining layer {layer.name()} due to problematic geometry."
+                    )
+                    continue
+
+                feature.setGeometry(geometry)
+
+            new_layer.addFeature(feature)
+
+        if not new_layer.commitChanges():
+            logger.warning(
+                f"Errors when writing features when offlining layer {layer.name()}: {new_layer.commitErrors()}"
+            )
 
         return new_layer.source()
 


### PR DESCRIPTION
A client reported a packaging job error when using the optimized packager.

The issue here has to do with how the legacy packager's QgsOfflineEditing class handles a failed layer commitChanges vs the new packager.

With the old packager, a warning was being thrown: https://github.com/qgis/QGIS/blob/master/src/core/qgsofflineediting.cpp#L866-L868

With the new package, we use the QGIS edit utility class (https://github.com/opengisch/libqfieldsync/blob/master/libqfieldsync/offliners.py#L331) which raises a fatal exception if the offlined features can't be commited (https://github.com/qgis/QGIS/blob/master/python/PyQt6/core/additions/edit.py#L38).

This PR aligns the behavior of the new optimized packager to only show a warning instead of derailing the whole packaging job.

In addition, code as been added to insure that the geometry inserted into the offlined geopackage layer is compatible with the data provider. If it is not compatible (the client issue to begin with), we skip _individual_ feature offlining instead of breaking the whole layer.
