### PR TITLE
Fix read-only files leading to uncaught exceptions

### DIFF
--- a/libqfieldsync/layer.py
+++ b/libqfieldsync/layer.py
@@ -1299,7 +1299,7 @@ class LayerSource:
                 source_path, file_name = os.path.split(file_to_copy)
                 dest_file = os.path.join(target_path, file_name)
                 if keep_existent is False or not os.path.isfile(dest_file):
-                    shutil.copy(os.path.join(source_path, file_name), dest_file)
+                    shutil.copyfile(os.path.join(source_path, file_name), dest_file)
 
             source_path, file_name = os.path.split(self.filename)
             new_source = ""
@@ -1365,7 +1365,7 @@ class LayerSource:
             source_path, file_name = os.path.split(file_path)
             dest_file = os.path.join(target_path, file_name)
             if not os.path.isfile(dest_file):
-                shutil.copy(os.path.join(source_path, file_name), dest_file)
+                shutil.copyfile(os.path.join(source_path, file_name), dest_file)
 
             if self.provider_metadata is not None:
                 metadata = self.metadata

--- a/libqfieldsync/utils/file_utils.py
+++ b/libqfieldsync/utils/file_utils.py
@@ -421,4 +421,4 @@ def copy_additional_project_files(
                     f"{export_project_stem_name}{match.group(1)}"
                 )
 
-        shutil.copy(additional_project_file, str(destination_file))
+        shutil.copyfile(additional_project_file, str(destination_file))


### PR DESCRIPTION
`shutil.copy` is just a wrapper calling `shitil.copyfile` AND `shutil.copymode`, but we don't necessarily want the mode of the file.


Fixes https://github.com/opengisch/qfieldsync/issues/797