### PR TITLE
 Avoid fatal errors when unable to offline a feature geometry or failing to commit changes into the offlined layer

### DIFF
--- a/libqfieldsync/offliners.py
+++ b/libqfieldsync/offliners.py
@@ -351,15 +351,17 @@ class PythonMiniOffliner(BaseOffliner):
             feature.setAttributes(attrs)
 
             if not feature.geometry().isNull():
-                geometry = new_layer.dataProvider().convertToProviderType(
-                    feature.geometry()
-                )
-                if geometry.isNull():
-                    # Skip feature containing a geometry that is incompatible with Geopackage
-                    logger.warning(
-                        f"Skipping feature ID {feature.id()} when offlining layer {layer.name()} due to problematic geometry."
+                geometry = feature.geometry()
+                if feature.geometry().wkbType() != new_layer.dataProvider().wkbType():
+                    geometry = new_layer.dataProvider().convertToProviderType(
+                        feature.geometry()
                     )
-                    continue
+                    if geometry.isNull():
+                        # Skip feature containing a geometry that is incompatible with Geopackage
+                        logger.warning(
+                            f"Skipping feature ID {feature.id()} when offlining layer {layer.name()} due to problematic geometry."
+                        )
+                        continue
 
                 feature.setGeometry(geometry)
 

--- a/libqfieldsync/offliners.py
+++ b/libqfieldsync/offliners.py
@@ -21,7 +21,6 @@ from qgis.core import (
     QgsProject,
     QgsRectangle,
     QgsVectorLayer,
-    edit,
 )
 from qgis.PyQt.QtCore import QFileInfo, QMetaType, QObject, pyqtSignal
 
@@ -328,25 +327,48 @@ class PythonMiniOffliner(BaseOffliner):
                 f"We were not able to create the layer {layer.name()} ..."
             )
 
-        with edit(new_layer):
-            new_fields = new_layer.fields()
+        if not new_layer.startEditing():
+            raise RuntimeError(
+                f"Cannot write into the offline Geopackage for {layer.name()}"
+            )
 
-            for feature in layer.dataProvider().getFeatures(feature_request):
-                # Prepend an empty attribute for the new FID
-                attrs = [None, *feature.attributes()]
+        new_fields = new_layer.fields()
 
-                # Fixup list and json attributes
-                for i in range(new_layer.fields().count()):
-                    field_type = new_layer.fields().at(i).type()
-                    if field_type in (
-                        QMetaType.Type.QStringList,
-                        QMetaType.Type.QVariantList,
-                    ):
-                        attrs[i] = QgsJsonUtils.encodeValue(attrs[i])
+        for feature in layer.dataProvider().getFeatures(feature_request):
+            # Prepend an empty attribute for the new FID
+            attrs = [None, *feature.attributes()]
 
-                feature.setFields(new_fields)
-                feature.setAttributes(attrs)
-                new_layer.addFeature(feature)
+            # Fixup list and json attributes
+            for i in range(new_layer.fields().count()):
+                field_type = new_layer.fields().at(i).type()
+                if field_type in (
+                    QMetaType.Type.QStringList,
+                    QMetaType.Type.QVariantList,
+                ):
+                    attrs[i] = QgsJsonUtils.encodeValue(attrs[i])
+
+            feature.setFields(new_fields)
+            feature.setAttributes(attrs)
+
+            if not feature.geometry().isNull():
+                geometry = new_layer.dataProvider().convertToProviderType(
+                    feature.geometry()
+                )
+                if geometry.isNull():
+                    # Skip feature containing a geometry that is incompatible with Geopackage
+                    logger.warning(
+                        f"Skipping feature ID {feature.id()} when offlining layer {layer.name()} due to problematic geometry."
+                    )
+                    continue
+
+                feature.setGeometry(geometry)
+
+            new_layer.addFeature(feature)
+
+        if not new_layer.commitChanges():
+            logger.warning(
+                f"Errors when writing features when offlining layer {layer.name()}: {new_layer.commitErrors()}"
+            )
 
         return new_layer.source()
 

--- a/tests/test_offline_converter_minioffliner.py
+++ b/tests/test_offline_converter_minioffliner.py
@@ -282,18 +282,21 @@ class OfflineConverterTest(unittest.TestCase):
 
         # spatialite layer
         layer = exported_project.mapLayersByName("somedata")[0]
+        self.assertEqual(layer.featureCount(), 5)
         self.assertEqual(layer.customProperty("QFieldSync/sourceDataPrimaryKeys"), "pk")
         self.assertIsNone(layer.customProperty("QFieldSync/unsupported_source_pk"))
         self.assertFalse(layer.readOnly())
 
         # spatialite layer
         layer = exported_project.mapLayersByName("somepolydata")[0]
+        self.assertEqual(layer.featureCount(), 4)
         self.assertEqual(layer.customProperty("QFieldSync/sourceDataPrimaryKeys"), "pk")
         self.assertIsNone(layer.customProperty("QFieldSync/unsupported_source_pk"))
         self.assertFalse(layer.readOnly())
 
         # gpkg layer
         layer = exported_project.mapLayersByName("curved_polys polys CurvePolygon")[0]
+        self.assertEqual(layer.featureCount(), 4)
         self.assertEqual(
             layer.customProperty("QFieldSync/sourceDataPrimaryKeys"), "fid"
         )
@@ -302,6 +305,7 @@ class OfflineConverterTest(unittest.TestCase):
 
         # shp layer
         layer = exported_project.mapLayersByName("france_parts_shape")[0]
+        self.assertEqual(layer.featureCount(), 4)
         self.assertIsNone(layer.customProperty("QFieldSync/sourceDataPrimaryKeys"))
         self.assertEqual(layer.customProperty("QFieldSync/unsupported_source_pk"), "1")
         self.assertTrue(layer.readOnly())

--- a/tests/test_offline_converter_minioffliner.py
+++ b/tests/test_offline_converter_minioffliner.py
@@ -22,7 +22,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from qgis.core import QgsProject
+from qgis.core import QgsFeature, QgsGeometry, QgsProject, QgsVectorLayer
 from qgis.testing import start_app
 from qgis.testing.mocked import get_iface
 
@@ -309,3 +309,56 @@ class OfflineConverterTest(unittest.TestCase):
         self.assertIsNone(layer.customProperty("QFieldSync/sourceDataPrimaryKeys"))
         self.assertEqual(layer.customProperty("QFieldSync/unsupported_source_pk"), "1")
         self.assertTrue(layer.readOnly())
+
+    def test_offline_convert_geometry(self):
+        project_instance = QgsProject.instance()
+        project = QgsProject()
+        QgsProject.setInstance(project)
+
+        memory_layer = QgsVectorLayer(
+            "MultiPolygon?crs=EPSG:4326&field=fid:integer(10,0)",
+            "multipolygons",
+            "memory",
+        )
+        memory_layer.setCustomProperty("QFieldSync/action", "offline")
+        project.setCrs(memory_layer.crs())
+        project.addMapLayer(memory_layer)
+
+        project_file = Path(tempfile.mkdtemp()).joinpath("project.qgz")
+        self.assertTrue(project.write(str(project_file)))
+
+        feature = QgsFeature(memory_layer.fields())
+        feature.setAttribute(0, 1)
+        feature.setGeometry(
+            QgsGeometry.fromWkt("Polygon ((104 12, 104 11, 105 11, 105 12, 104 12))")
+        )
+
+        memory_layer.dataProvider().addFeature(feature)
+        feature = memory_layer.getFeature(1)
+        self.assertEqual(
+            feature.geometry().asWkt(),
+            "Polygon ((104 12, 104 11, 105 11, 105 12, 104 12))",
+        )
+
+        offline_converter = OfflineConverter(
+            project,
+            self.target_dir.joinpath("project_qfield.qgs"),
+            "Polygon ((103 13, 103 10, 108 10, 108 13, 103 13))",
+            QgsProject.instance().crs().authid(),
+            ["DCIM"],
+            PythonMiniOffliner(),
+        )
+        offline_converter.convert()
+
+        exported_project = self.load_project(
+            self.target_dir.joinpath("project_qfield.qgs")
+        )
+        layer = exported_project.mapLayersByName("multipolygons")[0]
+        self.assertEqual(layer.featureCount(), 1)
+        feature = layer.getFeature(1)
+        self.assertEqual(
+            feature.geometry().asWkt(),
+            "MultiPolygon (((104 12, 104 11, 105 11, 105 12, 104 12)))",
+        )
+
+        QgsProject.setInstance(project_instance)


### PR DESCRIPTION
The Return of the Fix :wink: 

The problem was that QgsVectorDataProvider.convertToProviderType(geom) returns None if the passed on geometry wkb type matches the data provider wkb type. So null doesn't mean failure, it can also mean "no need to convert". Dubious API behavior ;)

That being said, I would also like to add a test case that would have revealed a failure when we merged the first PR.