### PR TITLE
feat: add project warning if a layer contains hardcoded pg credentials

### DIFF
--- a/libqfieldsync/project_checker.py
+++ b/libqfieldsync/project_checker.py
@@ -127,6 +127,11 @@ class ProjectChecker:
             },
             {
                 "level": Feedback.Level.WARNING,
+                "fn": self.check_pg_layer_no_hardcoded_credentials,
+                "scope": None,
+            },
+            {
+                "level": Feedback.Level.WARNING,
                 "fn": self.check_layer_primary_key,
                 "scope": ExportType.Cloud,
             },
@@ -482,6 +487,26 @@ class ProjectChecker:
                     "QFieldSync may not transfer your layer. "
                     'Please move the file to "{}".'
                 ).format(layer_source.filename, home_path)
+            )
+
+        return None
+
+    def check_pg_layer_no_hardcoded_credentials(
+        self, layer_source: LayerSource
+    ) -> Optional[FeedbackResult]:
+        """Check if PostgreSQL layer has no hardcoded credentials"""
+        layer = layer_source.layer
+
+        if layer.providerType() != "postgres":
+            return None
+
+        uri = layer.dataProvider().uri()
+        if uri.username() or uri.password():
+            return FeedbackResult(
+                self.tr(
+                    "The '{layer}' layer has hardcoded PostgreSQL credentials. "
+                    "Consider using a pg_service entry and a Secret in QFieldCloud."
+                ).format(layer=layer.name())
             )
 
         return None


### PR DESCRIPTION
Sister-PR of https://github.com/opengisch/QFieldCloud/pull/1820

-> add a project warning if a hardcoded pg credential is found in a layer of the project, since the go-to way is `pg_service` entry + QFieldCloud Secret.

<img width="577" height="98" alt="image" src="https://github.com/user-attachments/assets/91450a19-0d91-4853-9012-bef89bf20f41" />
